### PR TITLE
[Issue 2] Add pinned commands

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -8,12 +8,14 @@ interface BetterCommandPalettePluginSettings {
 	closeWithBackspace: boolean,
 	fileSearchPrefix: string,
 	suggestionLimit: number,
+	recentAbovePinned: boolean,
 }
 
 const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
 	closeWithBackspace: true,
 	fileSearchPrefix: '/',
 	suggestionLimit: 50,
+	recentAbovePinned: false,
 }
 
 export default class BetterCommandPalettePlugin extends Plugin {
@@ -72,6 +74,14 @@ class BetterCommandPaletteSettingTab extends PluginSettingTab {
 			.setDesc('Close the palette when there is no text and backspace is pressed')
 			.addToggle(t => t.setValue(settings.closeWithBackspace).onChange(async val => {
 				settings.closeWithBackspace = val;
+				await this.plugin.saveSettings();
+			}));
+
+		new Setting(containerEl)
+			.setName('Recent above Pinned')
+			.setDesc('Sorts the suggestion so that the recently used items show before pinned items.')
+			.addToggle(t => t.setValue(settings.recentAbovePinned).onChange(async val => {
+				settings.recentAbovePinned = val;
 				await this.plugin.saveSettings();
 			}));
 


### PR DESCRIPTION
1. Adds commands pinned in the command palette plugin into the better command palette
2. Adds a new setting letting to user select if recent items should be shown above or below pinned items
3. At the moment only commands can be pinned