### PR TITLE
Bugfix + minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # vscode
-.vscode 
+.vscode
 
 # Intellij
 *.iml
@@ -17,3 +17,6 @@ main.js
 
 # obsidian
 data.json
+
+# Mac
+.DS_Store

--- a/palette.ts
+++ b/palette.ts
@@ -190,10 +190,10 @@ class BetterCommandPaletteModal extends FuzzySuggestModal < any > {
         // Has a plugin name prefix
         if (text.includes(this.COMMAND_PLUGIN_NAME_SEPARATOR)) {
             // Wish there was an easy way to get the plugin name without string manipulation
-            // Seems like this is how the acutal command palette does it though
+            // Seems like this is how the actual command palette does it though
             const split = text.split(this.COMMAND_PLUGIN_NAME_SEPARATOR);
-            const prefix = split[0];
-            text = split[1];
+            const prefix = split.shift();
+            text = split.join(this.COMMAND_PLUGIN_NAME_SEPARATOR);
 
             el.createEl('span', {
                 cls: 'suggestion-prefix',

--- a/utils.ts
+++ b/utils.ts
@@ -43,8 +43,13 @@ export class OrderedSet<T> extends Set<T> {
  */
 export function generateHotKeyText(hotkey: Hotkey): string {
     var hotKeyStrings: string[] = [];
-    for (const mod of hotkey.modifiers) {
-        hotKeyStrings.push(MODIFIER_ICONS[mod])
+    if (hotkey.modifiers.length === 4) {
+        // for Mac users using the Hyper Key https://holmberg.io/hyper-key/
+        hotKeyStrings.push("⇪");
+    } else {
+        for (const mod of hotkey.modifiers) {
+            hotKeyStrings.push(MODIFIER_ICONS[mod])
+        }
     }
 
     const key = hotkey.key.toUpperCase();

--- a/utils.ts
+++ b/utils.ts
@@ -17,6 +17,7 @@ export const SPECIAL_KEYS : Record<string, string> = {
     ARROWUP: "↑",
     ARROWDOWN: "↓",
     BACKSPACE: "⌫",
+    ESC: "Esc",
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -6,6 +6,7 @@ export const MODIFIER_ICONS = {
     Meta: '⌘',
     Alt: '⌥',
     Shift: '⇧',
+    Capslock: '⇪',
 }
 
 export const SPECIAL_KEYS : Record<string, string> = {
@@ -45,7 +46,7 @@ export function generateHotKeyText(hotkey: Hotkey): string {
     var hotKeyStrings: string[] = [];
     if (hotkey.modifiers.length === 4) {
         // for Mac users using the Hyper Key https://holmberg.io/hyper-key/
-        hotKeyStrings.push("⇪");
+        hotKeyStrings.push(MODIFIER_ICONS["Capslock"]);
     } else {
         for (const mod of hotkey.modifiers) {
             hotKeyStrings.push(MODIFIER_ICONS[mod])


### PR DESCRIPTION
## Commit No. 1+2
Improves the Display of Hotkeys for Mac users who use [Karabiner Elements with the Hyper key feature](https://holmberg.io/hyper-key/). Basically, the app is used to remap `Capslock` to `cmd + shift + ctrl + alt` to get a 5th modifier key. In the command palette, this looks quite ugly and does not represent what you actually press on the keyboard.

## Commit No. 3
Change `ESC` as `Esc` in the hotkeys display.

## Commit No. 4 
fixes a bug where an additional `:` in the command name results in part of the command name not displayed properly.
<img width="500" alt="Screenshot 2022-01-28 15 23 01" src="https://user-images.githubusercontent.com/73286100/151569764-4d8cce6d-4350-4bbd-b3e7-c9970d41b6e5.png">
<img width="500" alt="Screenshot 2022-01-28 15 23 30" src="https://user-images.githubusercontent.com/73286100/151569744-b49762d1-0713-4228-bade-4bd87b1ba1d8.png">

## Commit No. 5
adds `.DS_Store` to `.gitignore`, that file only contains view states of the Mac System Explorer.