### PR TITLE
Add functionality for searching tags in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Obsidian Better Command Palette
-A plugin for Obsidian that adds a command palatte that is more user friendly. Use `cmd+shift+p` to to open the palette.
+A plugin for Obsidian that adds a command palatte that is more user friendly and more feature rich. Use `cmd+shift+p` to to open the palette.
 
 ## Features
 ### Backspace to close
 When the palette has no text entered into the input and you press backspace, then the palette will close. This can be turned off in the settings.
 
-### Recent Commands
-Commands that have been recently used will bubble up to the top of the command list.
+### Recent Choices
+Choices that have been recently used will bubble up to the top of the command list.
+
+### Pinned Commands
+Commands that have been pinned in the default `Command Palette` will be pinned here as well.
 
 ### File Opening
 Better Command Palette allows you to open files from the same input without needing to run a command or press `cmd+o first`. Once the palette is open just type `/` (This can be changed in the settings) and you will be searching files to open. Press `enter` to open the file in the active pane or prese `cmd+enter` to open the file in a new pane.
@@ -14,3 +17,7 @@ Better Command Palette allows you to open files from the same input without need
 ### File Creation
 If after searching for files to open there are no results you may press `cmd+enter` to create a file with the same name as you have entered. You may specify directories.
 **NOTE: Currently the plugin will not create directories for you.**
+
+### File Searching using Tags
+Better Command Palette allows you to find and open files that contain the tags you search for.
+Type `#` (configurable in the settings) to begin searching for files that have that tag. Press enter to open the selected file.

--- a/main.ts
+++ b/main.ts
@@ -25,6 +25,7 @@ export default class BetterCommandPalettePlugin extends Plugin {
 	settings: BetterCommandPalettePluginSettings;
 	prevCommands : OrderedSet<Match>;
 	prevFiles : OrderedSet<Match>;
+	prevTags : OrderedSet<Match>;
 	suggestionsWorker : Worker;
 
 	async onload() {
@@ -32,8 +33,9 @@ export default class BetterCommandPalettePlugin extends Plugin {
 
 		await this.loadSettings();
 
-		this.prevCommands = new OrderedSet<Match>()
-		this.prevFiles = new OrderedSet<Match>()
+		this.prevCommands = new OrderedSet<Match>();
+		this.prevFiles = new OrderedSet<Match>();
+		this.prevTags = new OrderedSet<Match>();
 		this.suggestionsWorker = new SuggestionsWorker({});
 
 		this.addCommand({
@@ -47,6 +49,7 @@ export default class BetterCommandPalettePlugin extends Plugin {
 					this.app,
 					this.prevCommands,
 					this.prevFiles,
+					this.prevTags,
 					this,
 					this.suggestionsWorker
 				).open();

--- a/main.ts
+++ b/main.ts
@@ -40,7 +40,7 @@ export default class BetterCommandPalettePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'open-better-commmand-palette',
-			name: 'Open better command palette',
+			name: 'Open better command palette: Test',
 			// Generally I would not set a hotkey, but since it is a command palette I think it makes sense
 			// Can still be overwritten in the hotkey settings
 			hotkeys: [{ modifiers: ["Mod", "Shift"], key: "p" }],

--- a/main.ts
+++ b/main.ts
@@ -40,7 +40,7 @@ export default class BetterCommandPalettePlugin extends Plugin {
 
 		this.addCommand({
 			id: 'open-better-commmand-palette',
-			name: 'Open better command palette: Test',
+			name: 'Open better command palette',
 			// Generally I would not set a hotkey, but since it is a command palette I think it makes sense
 			// Can still be overwritten in the hotkey settings
 			hotkeys: [{ modifiers: ["Mod", "Shift"], key: "p" }],

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,7 @@ import { Match } from './types';
 interface BetterCommandPalettePluginSettings {
 	closeWithBackspace: boolean,
 	fileSearchPrefix: string,
+	tagSearchPrefix: string,
 	suggestionLimit: number,
 	recentAbovePinned: boolean,
 }
@@ -15,6 +16,7 @@ interface BetterCommandPalettePluginSettings {
 const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
 	closeWithBackspace: true,
 	fileSearchPrefix: '/',
+	tagSearchPrefix: '#',
 	suggestionLimit: 50,
 	recentAbovePinned: false,
 }
@@ -99,6 +101,14 @@ class BetterCommandPaletteSettingTab extends PluginSettingTab {
 			.setDesc('The prefix used to tell the palette you want to search files')
 			.addText(t => t.setValue(settings.fileSearchPrefix).onChange(async val => {
 				settings.fileSearchPrefix = val;
+				await this.plugin.saveSettings();
+			}));
+
+		new Setting(containerEl)
+			.setName('Tag Search Prefix')
+			.setDesc('The prefix used to tell the palette you want to search tags')
+			.addText(t => t.setValue(settings.tagSearchPrefix).onChange(async val => {
+				settings.tagSearchPrefix = val;
 				await this.plugin.saveSettings();
 			}));
 

--- a/palette-modal-adapters/command-adapter.ts
+++ b/palette-modal-adapters/command-adapter.ts
@@ -1,0 +1,89 @@
+import { App, Command, setIcon } from "obsidian";
+import { Match} from "types";
+import { generateHotKeyText, OrderedSet, PaletteMatch, SuggestModalAdapter } from "utils";
+
+export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
+    COMMAND_PLUGIN_NAME_SEPARATOR: string = ': ';
+
+    allItems: Match[];
+    pinnedItems: Match[];
+
+    constructor(app: App, prevItems: OrderedSet<Match>, recentAbovePinned: boolean) {
+        super(app, prevItems, recentAbovePinned);
+        // @ts-ignore Can't find another way to access commands. Seems like other plugins have used this.
+        this.allItems = this.app.commands.listCommands()
+            .sort((a: Command, b: Command) => b.name.localeCompare(a.name))
+            .map((c: Command): Match => new PaletteMatch(c.id, c.name));
+
+        // @ts-ignore Don't love accessing the internal plugin, but that's where it's stored
+        this.pinnedItems = this.app.internalPlugins.getPluginById('command-palette').instance.options.pinned.map(
+            // @ts-ignore Get the command object using the command id
+            (id: string): Match => new PaletteMatch(id, this.app.commands.findCommand(id).name)
+        );
+    }
+
+    getTitleText(): string {
+        return 'Better Command Palette: Commands';
+    }
+
+    getEmptyStateText(): string {
+        return 'No matching commands.';
+    }
+
+    renderSuggestion(match: Match, el: HTMLElement): void {
+        // @ts-ignore
+        const command = this.app.commands.findCommand(match.id);
+        // @ts-ignore Need to access hotkeyManager to get custom hotkeys
+        const customHotkeys = this.app.hotkeyManager.getHotkeys(command.id);
+        // @ts-ignore Need to access hotkeyManager to get default hotkeys
+        const defaultHotkeys = this.app.hotkeyManager.getDefaultHotkeys(command.id);
+
+        // If hotkeys have been customized in some way (add new, deleted default) customHotkeys will be an array, otherwise undefined
+        // If there is a default hotkey defaultHotkeys will be an array (does not check any customization), otherwise undefined.
+        const hotkeys = customHotkeys || defaultHotkeys || [];
+
+
+
+        if (this.getPinnedItems().find(i => i.id === match.id)) {
+            const flairContainer = el.createEl('span', 'suggestion-flair');
+            // 13 copied from current command palette
+            setIcon(flairContainer, 'filled-pin', 13);
+        }
+
+        let text = match.text;
+
+        // Has a plugin name prefix
+        if (text.includes(this.COMMAND_PLUGIN_NAME_SEPARATOR)) {
+            // Wish there was an easy way to get the plugin name without string manipulation
+            // Seems like this is how the acutal command palette does it though
+            const split = text.split(this.COMMAND_PLUGIN_NAME_SEPARATOR);
+            const prefix = split[0];
+            text = split[1];
+
+            el.createEl('span', {
+                cls: 'suggestion-prefix',
+                text: prefix,
+            })
+        }
+
+        el.createEl('span', {
+            cls: 'suggestion-content',
+            text,
+        });
+
+
+        for (const hotkey of hotkeys) {
+            el.createEl('kbd', {
+                cls: 'suggestion-hotkey',
+                text: generateHotKeyText(hotkey),
+            })
+        }
+    }
+
+    async onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent) {
+        this.getPrevItems().add(match);
+        // @ts-ignore Can't find another way to access commands. Seems like other plugins have used this.
+        this.app.commands.executeCommandById(match.id);
+    };
+
+}

--- a/palette-modal-adapters/command-adapter.ts
+++ b/palette-modal-adapters/command-adapter.ts
@@ -1,6 +1,6 @@
 import { App, Command, setIcon } from "obsidian";
 import { Match} from "types";
-import { generateHotKeyText, OrderedSet, PaletteMatch, SuggestModalAdapter } from "utils";
+import { generateHotKeyText, PaletteMatch, SuggestModalAdapter } from "utils";
 
 export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
     COMMAND_PLUGIN_NAME_SEPARATOR: string = ': ';
@@ -8,8 +8,9 @@ export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
     allItems: Match[];
     pinnedItems: Match[];
 
-    constructor(app: App, prevItems: OrderedSet<Match>, recentAbovePinned: boolean) {
-        super(app, prevItems, recentAbovePinned);
+    initialize() {
+        super.initialize();
+
         // @ts-ignore Can't find another way to access commands. Seems like other plugins have used this.
         this.allItems = this.app.commands.listCommands()
             .sort((a: Command, b: Command) => b.name.localeCompare(a.name))

--- a/palette-modal-adapters/command-adapter.ts
+++ b/palette-modal-adapters/command-adapter.ts
@@ -16,7 +16,8 @@ export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
             .map((c: Command): Match => new PaletteMatch(c.id, c.name));
 
         // @ts-ignore Don't love accessing the internal plugin, but that's where it's stored
-        this.pinnedItems = this.app.internalPlugins.getPluginById('command-palette').instance.options.pinned.map(
+        const pinnedCommands = this.app.internalPlugins.getPluginById('command-palette').instance.options.pinned || [];
+        this.pinnedItems = pinnedCommands.map(
             // @ts-ignore Get the command object using the command id
             (id: string): Match => new PaletteMatch(id, this.app.commands.findCommand(id).name)
         );

--- a/palette-modal-adapters/command-adapter.ts
+++ b/palette-modal-adapters/command-adapter.ts
@@ -59,8 +59,9 @@ export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
             // Wish there was an easy way to get the plugin name without string manipulation
             // Seems like this is how the acutal command palette does it though
             const split = text.split(this.COMMAND_PLUGIN_NAME_SEPARATOR);
-            const prefix = split[0];
-            text = split[1];
+            // Get first element
+            const prefix = split.shift();
+            text = split.join(this.COMMAND_PLUGIN_NAME_SEPARATOR);
 
             el.createEl('span', {
                 cls: 'suggestion-prefix',

--- a/palette-modal-adapters/file-adapter.ts
+++ b/palette-modal-adapters/file-adapter.ts
@@ -1,0 +1,64 @@
+import { App, normalizePath } from "obsidian";
+import { Match } from "types";
+import { OrderedSet, PaletteMatch, SuggestModalAdapter } from "utils";
+
+export class BetterCommandPaletteFileAdapter extends SuggestModalAdapter {
+    allItems: Match[];
+    fileSearchPrefix: string;
+
+    constructor(app: App, prevItems: OrderedSet<Match>, recentAbovePinned: boolean, fileSearchPrefix: string) {
+        super(app, prevItems, recentAbovePinned)
+        this.fileSearchPrefix = fileSearchPrefix;
+        // @ts-ignore To support searching every file 'getCachedFiles' is much faster
+        this.allItems = this.app.metadataCache.getCachedFiles()
+            .reverse() // Reversed because we want it sorted A -> Z
+            .map((path: string) => new PaletteMatch(path, path));
+    }
+
+    cleanQuery(query: string): string {
+        const newQuery = query.replace(this.fileSearchPrefix, '')
+        return newQuery;
+    }
+
+    getTitleText(): string {
+        return 'Better Command Palette: Files';
+    }
+
+    getEmptyStateText(): string {
+        return 'No matching files. ⌘+Enter to create the file.';
+    }
+
+    renderSuggestion(match: Match, el: HTMLElement): void {
+        el.createEl('span', {
+            cls: 'suggestion-content',
+            text: match.text,
+        });
+    }
+
+    async onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent) {
+        let created = false;
+        let file = null;
+
+        if (!match) {
+            created = true;
+            // @ts-ignore Event target's definitely have a `value`. Maybe I'm missing something about TS
+            const path = normalizePath(`${event.target.value.replace(this.fileSearchPrefix, '')}.md`);
+            file = await this.app.vault.create(path, '');
+            match = new PaletteMatch(file.path, file.path);
+        } else {
+            file = this.app.metadataCache.getFirstLinkpathDest(match.id, '');
+        }
+
+        this.getPrevItems().add(match);
+        const workspace = this.app.workspace;
+
+        if (event.metaKey && !created) {
+            const newLeaf = workspace.createLeafBySplit(workspace.activeLeaf)
+            newLeaf.openFile(file);
+            workspace.setActiveLeaf(newLeaf);
+        } else {
+            workspace.activeLeaf.openFile(file);
+        }
+    };
+
+}

--- a/palette-modal-adapters/file-adapter.ts
+++ b/palette-modal-adapters/file-adapter.ts
@@ -9,6 +9,11 @@ export class BetterCommandPaletteFileAdapter extends SuggestModalAdapter {
     constructor(app: App, prevItems: OrderedSet<Match>, recentAbovePinned: boolean, fileSearchPrefix: string) {
         super(app, prevItems, recentAbovePinned)
         this.fileSearchPrefix = fileSearchPrefix;
+    }
+
+    initialize() {
+        super.initialize();
+
         // @ts-ignore To support searching every file 'getCachedFiles' is much faster
         this.allItems = this.app.metadataCache.getCachedFiles()
             .reverse() // Reversed because we want it sorted A -> Z

--- a/palette-modal-adapters/index.ts
+++ b/palette-modal-adapters/index.ts
@@ -1,0 +1,3 @@
+export * from './command-adapter';
+export * from './file-adapter';
+export * from './tag-adapter';

--- a/palette-modal-adapters/tag-adapter.ts
+++ b/palette-modal-adapters/tag-adapter.ts
@@ -1,0 +1,38 @@
+import { App } from "obsidian";
+import { Match } from "types";
+import { OrderedSet, PaletteMatch, SuggestModalAdapter } from "utils";
+
+export class BetterCommandPaletteTagAdapter extends SuggestModalAdapter {
+    allItems: Match[];
+
+    constructor(app: App, prevItems: OrderedSet<Match>, recentAbovePinned: boolean) {
+        super(app, prevItems, recentAbovePinned)
+
+        // @ts-ignore Can't find another way to access tags.
+        this.allItems = Object.keys(this.app.metadataCache.getTags())
+            .map((tag) => new PaletteMatch(tag, tag));
+    }
+
+    getTitleText(): string {
+        return 'Better Command Palette: Tags';
+    }
+
+    getEmptyStateText(): string {
+        return 'No matching tags.';
+    }
+
+    renderSuggestion(match: Match, el: HTMLElement): void {
+        el.createEl('span', {
+            cls: 'suggestion-content',
+            text: match.text,
+        });
+    }
+
+    async onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent) {
+        this.getPrevItems().add(match);
+        // @ts-ignore
+        this.app.internalPlugins.plugins['global-search'].instance.openGlobalSearch(`tag:${match.text}`)
+        console.log(match);
+    };
+
+}

--- a/palette.ts
+++ b/palette.ts
@@ -4,15 +4,17 @@ import { generateHotKeyText, OrderedSet, PaletteMatch } from "./utils";
 import { Match } from './types';
 
 class BetterCommandPaletteModal extends SuggestModal <any> {
-    ACTION_TYPE_COMMAND: string = 'command';
-    ACTION_TYPE_FILES: string = 'files';
+    ACTION_TYPE_COMMAND: number = 1;
+    ACTION_TYPE_FILES: number = 2;
+    ACTION_TYPE_TAGS: number = 3;
 
     COMMAND_PLUGIN_NAME_SEPARATOR: string = ': ';
 
-    actionType: string;
+    actionType: number;
     prevCommands: OrderedSet<Match>;
     prevFiles: OrderedSet<Match>;
     fileSearchPrefix: string;
+    tagSearchPrefix: string;
     recentAbovePinned: boolean;
     suggestionsWorker: Worker;
     currentSuggestions: Match[];
@@ -23,6 +25,7 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
         this.prevCommands = prevCommands;
         this.prevFiles = prevFiles;
         this.fileSearchPrefix = plugin.settings.fileSearchPrefix;
+        this.tagSearchPrefix = plugin.settings.tagSearchPrefix;
         this.limit = plugin.settings.suggestionLimit;
         this.recentAbovePinned = plugin.settings.recentAbovePinned;
         this.currentSuggestions = [];

--- a/palette.ts
+++ b/palette.ts
@@ -54,10 +54,9 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
         this.tagAdapter = new BetterCommandPaletteTagAdapter(
             app,
             prevTags,
-            plugin.settings.recentAbovePinned
+            plugin.settings.recentAbovePinned,
+            this.tagSearchPrefix,
         );
-
-        this.currentAdapter = this.commandAdapter;
 
         // Lets us do the suggestion fuzzy search in a different thread
         this.suggestionsWorker = suggestionsWorker;
@@ -67,7 +66,6 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
         this.setPlaceholder('Select a command')
 
         this.modalTitleEl = createEl('p', {
-            text: this.currentAdapter.getTitleText(),
             cls: 'better-command-palette-title'
         });
 
@@ -104,8 +102,7 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
 
 	updateActionType() : boolean {
         const text: string = this.inputEl.value;
-        let type = this.ACTION_TYPE_COMMAND
-        this.currentAdapter = this.commandAdapter;
+        let type;
 
         if (text.startsWith(this.fileSearchPrefix)) {
             type = this.ACTION_TYPE_FILES;
@@ -113,6 +110,13 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
         } else if (text.startsWith(this.tagSearchPrefix)) {
             type = this.ACTION_TYPE_TAGS;
             this.currentAdapter = this.tagAdapter;
+        } else {
+            type = this.ACTION_TYPE_COMMAND
+            this.currentAdapter = this.commandAdapter;
+        }
+
+        if (!this.currentAdapter.initialized) {
+            this.currentAdapter.initialize();
         }
 
         const wasUpdated = type !== this.actionType;
@@ -185,8 +189,8 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
     }
 
 	renderSuggestion(match: Match, el: HTMLElement) {
-        this.currentAdapter.renderSuggestion(match, el);
         this.renderPrevItems(match, el, this.currentAdapter.getPrevItems());
+        this.currentAdapter.renderSuggestion(match, el);
     }
 
 	async onChooseSuggestion(item: Match, event: MouseEvent | KeyboardEvent) {

--- a/styles.css
+++ b/styles.css
@@ -2,11 +2,17 @@
     color: var(--text-accent);
     margin: 5px;
 }
-.recent {
+.recent .suggestion-content {
     font-weight: bold;
 }
 
 .recent-text {
     color: var(--text-faint);
     margin-left: 10px;
+    float: right;
+}
+
+.suggestion-sub-content {
+    color: var(--text-muted);
+    float: right;
 }

--- a/utils.ts
+++ b/utils.ts
@@ -17,6 +17,7 @@ export const SPECIAL_KEYS : Record<string, string> = {
     ARROWUP: "↑",
     ARROWDOWN: "↓",
     BACKSPACE: "⌫",
+    ESC: 'Esc',
 }
 
 /**

--- a/utils.ts
+++ b/utils.ts
@@ -79,6 +79,8 @@ export abstract class SuggestModalAdapter {
     prevItems: OrderedSet<Match>;
     recentAbovePinned: boolean;
 
+    pinnedItems: Match[] = [];
+
     abstract allItems: Match[];
 
     abstract getTitleText(): string;
@@ -97,7 +99,7 @@ export abstract class SuggestModalAdapter {
     }
 
     getPinnedItems(): Match[] {
-        return []
+        return this.pinnedItems;
     }
 
     getItems(): Match[] {

--- a/utils.ts
+++ b/utils.ts
@@ -78,10 +78,9 @@ export abstract class SuggestModalAdapter {
     app: App;
     prevItems: OrderedSet<Match>;
     recentAbovePinned: boolean;
-
-    pinnedItems: Match[] = [];
-
-    abstract allItems: Match[];
+    pinnedItems: Match[];
+    initialized: boolean;
+    allItems: Match[];
 
     abstract getTitleText(): string;
     abstract getEmptyStateText():  string;
@@ -92,6 +91,19 @@ export abstract class SuggestModalAdapter {
         this.app = app;
         this.prevItems = prevItems;
         this.recentAbovePinned = recentAbovePinned;
+        this.allItems = []
+        this.pinnedItems = [];
+        this.initialized = false;
+    }
+
+    checkInitialized() {
+        if (!this.initialized) {
+            throw new Error('This adapter has not been initialized');
+        }
+    }
+
+    initialize() {
+        this.initialized = true;
     }
 
     cleanQuery(query: string) {
@@ -99,10 +111,12 @@ export abstract class SuggestModalAdapter {
     }
 
     getPinnedItems(): Match[] {
+        this.checkInitialized()
         return this.pinnedItems;
     }
 
     getItems(): Match[] {
+        this.checkInitialized()
         return this.allItems;
     }
 


### PR DESCRIPTION
Overall pretty big refactor here
1. Add in a palette adapter paradigm to cut down on all of the switch statements.
2. Use the adapters to only initialize data for the needed functions
2. Add the ability to search files via tags

Also fixes a few bugs:
1. Fixes crashing when no commands are pinned.
2. Fixes command names that contain more than one colon.
3. Fix the `Escape` hotkey text being all capitalized.