### PR TITLE
Add utility commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # vscode
-.vscode 
+.vscode
 
 # Intellij
 *.iml
@@ -17,3 +17,6 @@ main.js
 
 # obsidian
 data.json
+
+# Mac
+.DS_Store

--- a/main.ts
+++ b/main.ts
@@ -56,6 +56,40 @@ export default class BetterCommandPalettePlugin extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: 'open-better-commmand-palette-file-search',
+			name: 'Open better command palette: File Search',
+			hotkeys: [],
+			callback: () => {
+				new BetterCommandPaletteModal(
+					this.app,
+					this.prevCommands,
+					this.prevFiles,
+					this.prevTags,
+					this,
+					this.suggestionsWorker,
+					this.settings.fileSearchPrefix,
+				).open();
+			}
+		});
+
+		this.addCommand({
+			id: 'open-better-commmand-palette-tag-search',
+			name: 'Open better command palette: Tag Search',
+			hotkeys: [],
+			callback: () => {
+				new BetterCommandPaletteModal(
+					this.app,
+					this.prevCommands,
+					this.prevFiles,
+					this.prevTags,
+					this,
+					this.suggestionsWorker,
+					this.settings.tagSearchPrefix,
+				).open();
+			}
+		});
+
 		this.addSettingTab(new BetterCommandPaletteSettingTab(this.app, this));
 	}
 

--- a/palette-modal-adapters/command-adapter.ts
+++ b/palette-modal-adapters/command-adapter.ts
@@ -1,9 +1,12 @@
 import { App, Command, setIcon } from "obsidian";
 import { Match} from "types";
-import { generateHotKeyText, PaletteMatch, SuggestModalAdapter } from "utils";
+import { generateHotKeyText, PaletteMatch, SuggestModalAdapter, UnsafeAppInterface } from "utils";
 
 export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
     COMMAND_PLUGIN_NAME_SEPARATOR: string = ': ';
+
+    // Unsafe Interfaces
+    app: UnsafeAppInterface;
 
     allItems: Match[];
     pinnedItems: Match[];
@@ -11,15 +14,12 @@ export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
     initialize() {
         super.initialize();
 
-        // @ts-ignore Can't find another way to access commands. Seems like other plugins have used this.
         this.allItems = this.app.commands.listCommands()
             .sort((a: Command, b: Command) => b.name.localeCompare(a.name))
             .map((c: Command): Match => new PaletteMatch(c.id, c.name));
 
-        // @ts-ignore Don't love accessing the internal plugin, but that's where it's stored
         const pinnedCommands = this.app.internalPlugins.getPluginById('command-palette').instance.options.pinned || [];
         this.pinnedItems = pinnedCommands.map(
-            // @ts-ignore Get the command object using the command id
             (id: string): Match => new PaletteMatch(id, this.app.commands.findCommand(id).name)
         );
     }
@@ -33,11 +33,8 @@ export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
     }
 
     renderSuggestion(match: Match, el: HTMLElement): void {
-        // @ts-ignore
         const command = this.app.commands.findCommand(match.id);
-        // @ts-ignore Need to access hotkeyManager to get custom hotkeys
         const customHotkeys = this.app.hotkeyManager.getHotkeys(command.id);
-        // @ts-ignore Need to access hotkeyManager to get default hotkeys
         const defaultHotkeys = this.app.hotkeyManager.getDefaultHotkeys(command.id);
 
         // If hotkeys have been customized in some way (add new, deleted default) customHotkeys will be an array, otherwise undefined
@@ -85,7 +82,6 @@ export class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
 
     async onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent) {
         this.getPrevItems().add(match);
-        // @ts-ignore Can't find another way to access commands. Seems like other plugins have used this.
         this.app.commands.executeCommandById(match.id);
     };
 

--- a/palette-modal-adapters/file-adapter.ts
+++ b/palette-modal-adapters/file-adapter.ts
@@ -1,8 +1,11 @@
 import { App, normalizePath } from "obsidian";
 import { Match } from "types";
-import { OrderedSet, PaletteMatch, SuggestModalAdapter } from "utils";
+import { OrderedSet, PaletteMatch, SuggestModalAdapter, UnsafeAppInterface } from "utils";
 
 export class BetterCommandPaletteFileAdapter extends SuggestModalAdapter {
+    // Unsafe interface
+    app: UnsafeAppInterface;
+
     allItems: Match[];
     fileSearchPrefix: string;
 
@@ -14,7 +17,6 @@ export class BetterCommandPaletteFileAdapter extends SuggestModalAdapter {
     initialize() {
         super.initialize();
 
-        // @ts-ignore To support searching every file 'getCachedFiles' is much faster
         this.allItems = this.app.metadataCache.getCachedFiles()
             .reverse() // Reversed because we want it sorted A -> Z
             .map((path: string) => new PaletteMatch(path, path));
@@ -46,8 +48,10 @@ export class BetterCommandPaletteFileAdapter extends SuggestModalAdapter {
 
         if (!match) {
             created = true;
-            // @ts-ignore Event target's definitely have a `value`. Maybe I'm missing something about TS
-            const path = normalizePath(`${event.target.value.replace(this.fileSearchPrefix, '')}.md`);
+
+            const el = event.target as HTMLInputElement;
+            const path = normalizePath(`${el.value.replace(this.fileSearchPrefix, '')}.md`);
+
             file = await this.app.vault.create(path, '');
             match = new PaletteMatch(file.path, file.path);
         } else {

--- a/palette-modal-adapters/tag-adapter.ts
+++ b/palette-modal-adapters/tag-adapter.ts
@@ -1,8 +1,11 @@
 import { App } from "obsidian";
 import { Match } from "types";
-import { OrderedSet, PaletteMatch, SuggestModalAdapter } from "utils";
+import { OrderedSet, PaletteMatch, SuggestModalAdapter, UnsafeAppInterface } from "utils";
 
 export class BetterCommandPaletteTagAdapter extends SuggestModalAdapter {
+    // Unsafe interface
+    app: UnsafeAppInterface;
+
     allItems: Match[];
     tagSearchPrefix: string;
 
@@ -14,7 +17,6 @@ export class BetterCommandPaletteTagAdapter extends SuggestModalAdapter {
     initialize(): void {
         super.initialize();
 
-        // @ts-ignore get all files with tags
         this.allItems = this.app.metadataCache.getCachedFiles().reduce((acc: PaletteMatch[], path: string) => {
             const fileCache = this.app.metadataCache.getCache(path);
             if (fileCache.tags) {

--- a/palette.ts
+++ b/palette.ts
@@ -1,5 +1,4 @@
-// import BetterCommandPalettePlugin from "./main";
-import { App, KeymapEventListener, SuggestModal } from "obsidian";
+import { App, SuggestModal } from "obsidian";
 import { OrderedSet, PaletteMatch, SuggestModalAdapter } from "./utils";
 import {
     BetterCommandPaletteCommandAdapter,
@@ -39,11 +38,16 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
     ) {
         super(app);
 
+        // General instance variables
         this.fileSearchPrefix = plugin.settings.fileSearchPrefix;
         this.tagSearchPrefix = plugin.settings.tagSearchPrefix;
         this.limit = plugin.settings.suggestionLimit;
         this.initialInputValue = initialInputValue;
 
+        // The only time the input will be empty will be when we are searching commands
+        this.setPlaceholder('Select a command')
+
+        // Set up all of our different adapters
         this.commandAdapter = new BetterCommandPaletteCommandAdapter(
             app,
             prevCommands,
@@ -66,17 +70,22 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
         this.suggestionsWorker = suggestionsWorker;
         this.suggestionsWorker.onmessage = (msg: MessageEvent) => this.receivedSuggestions(msg);
 
-
-        this.setPlaceholder('Select a command')
-
+        // Add our custom title element
         this.modalTitleEl = createEl('p', {
             cls: 'better-command-palette-title'
         });
 
+        // Update our action type before adding in our title element so the text is correct
         this.updateActionType();
 
+        // Add in the title element
         this.modalEl.insertBefore(this.modalTitleEl, this.modalEl.firstChild);
 
+        // Set our scopes for the modal
+        this.setScopes(plugin);
+    }
+
+    setScopes(plugin: BetterCommandPalettePlugin) {
         const closeModal = (event: KeyboardEvent) => {
             // Have to cast this to access `value`
             const el = event.target as HTMLInputElement;

--- a/palette.ts
+++ b/palette.ts
@@ -1,5 +1,5 @@
 import { App, SuggestModal } from "obsidian";
-import { OrderedSet, PaletteMatch, SuggestModalAdapter } from "./utils";
+import { OrderedSet, PaletteMatch, SuggestModalAdapter, UnsafeSuggestModalInterface } from "./utils";
 import {
     BetterCommandPaletteCommandAdapter,
     BetterCommandPaletteFileAdapter,
@@ -8,10 +8,14 @@ import {
 import { Match } from './types';
 import BetterCommandPalettePlugin from "main";
 
-class BetterCommandPaletteModal extends SuggestModal <any> {
+class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSuggestModalInterface  {
     ACTION_TYPE_COMMAND: number = 1;
     ACTION_TYPE_FILES: number = 2;
     ACTION_TYPE_TAGS: number = 3;
+
+    // Unsafe interface
+    chooser: UnsafeSuggestModalInterface['chooser'];
+    updateSuggestions: UnsafeSuggestModalInterface['updateSuggestions'];
 
     actionType: number;
     fileSearchPrefix: string;
@@ -107,7 +111,6 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
 
         this.scope.register(['Meta'], 'Enter', () => {
             if (this.actionType === this.ACTION_TYPE_FILES) {
-                // @ts-ignore Until I know otherise I'll grab the currently chosen item from the `chooser`
                 this.chooser.useSelectedItem({ metaKey: true });
             }
         });
@@ -172,7 +175,6 @@ class BetterCommandPaletteModal extends SuggestModal <any> {
         const results = msg.data.slice(0, this.limit)
         const matches = results.map((r : Record<string, string>) => new PaletteMatch(r.id, r.text))
         this.currentSuggestions = matches;
-        // @ts-ignore
         this.updateSuggestions();
     }
 

--- a/utils.ts
+++ b/utils.ts
@@ -1,4 +1,4 @@
-import { App, Hotkey} from "obsidian";
+import { App, Command, Hotkey, MetadataCache, SuggestModal} from "obsidian";
 import { Comparable, Match } from "types";
 
 export const MODIFIER_ICONS = {
@@ -163,4 +163,36 @@ export function generateHotKeyText(hotkey: Hotkey): string {
     hotKeyStrings.push(SPECIAL_KEYS[key] || key)
 
     return hotKeyStrings.join(' ')
+}
+
+// Unsafe Interfaces
+// Ideally we would not have to use these, but as far as I can tell they are the only way for certain
+// functionality.
+// Copied this pattern from Another Quick Switcher: https://github.com/tadashi-aikawa/obsidian-another-quick-switcher/blob/master/src/ui/AnotherQuickSwitcherModal.ts#L109
+
+export interface UnsafeSuggestModalInterface extends SuggestModal<Match> {
+    chooser: {
+        useSelectedItem(ev: Partial<KeyboardEvent>): void;
+    }
+    updateSuggestions(): void;
+}
+
+interface UnsafeMetadataCacheInterface extends MetadataCache {
+    getCachedFiles(): string[],
+}
+
+export interface UnsafeAppInterface extends App {
+    commands: {
+        listCommands(): Command[],
+        findCommand(id: string): Command,
+        executeCommandById(id: string): void,
+    },
+    hotkeyManager: {
+        getHotkeys(id: string): Hotkey[],
+        getDefaultHotkeys(id: string): Hotkey[],
+    },
+    metadataCache: UnsafeMetadataCacheInterface,
+    internalPlugins: {
+        getPluginById(id: string): { instance: { options: { pinned: [] }}},
+    }
 }


### PR DESCRIPTION
1. Adds a command to open the palette directly to the file search
2. Adds a command to open the palette directly to the tag search
3. Cleans up the modal constructor
4. Removes uses of `ts-ignore` in favor of using unsafe interfaces to be more explicit
5. Add `.DS_Store` to `.gitignore`