### PR TITLE
[Issue 22] Fix pinned commands being reversed from the regular palette

### DIFF
--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -29,7 +29,7 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
             .map((c: Command): Match => new PaletteMatch(c.id, c.name));
 
         const pinnedCommands = this.app.internalPlugins.getPluginById('command-palette').instance.options.pinned || [];
-        this.pinnedItems = pinnedCommands.map(
+        this.pinnedItems = pinnedCommands.reverse().map(
             (id: string): Match => new PaletteMatch(id, this.app.commands.findCommand(id).name),
         );
     }


### PR DESCRIPTION
1. Reverses the pinned commands we get from the regular command palette so that they are in the same order.