### PR TITLE
[Issue 28 ] OS hotkeys and settings

### DIFF
--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -1,6 +1,6 @@
 import { Command, Instruction, setIcon } from 'obsidian';
 import {
-    generateHotKeyText, PaletteMatch, SPECIAL_KEYS, SuggestModalAdapter,
+    generateHotKeyText, PaletteMatch, SuggestModalAdapter,
 } from 'src/utils';
 import { Match, UnsafeAppInterface } from 'src/types/types';
 
@@ -45,9 +45,12 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
     }
 
     getInstructions(): Instruction[] {
+        const backspaceHotkeyText = generateHotKeyText({ modifiers: [], key: 'BACKSPACE' }, this.plugin.settings);
+        const escapeHotkeyText = generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings);
+
         return [
-            { command: SPECIAL_KEYS.ENTER, purpose: 'Run command' },
-            { command: `${SPECIAL_KEYS.BACKSPACE} / ${SPECIAL_KEYS.ESC}`, purpose: 'Close palette' },
+            { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Run command' },
+            { command: `${backspaceHotkeyText} / ${escapeHotkeyText}`, purpose: 'Close palette' },
         ];
     }
 
@@ -93,7 +96,7 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
         hotkeys.forEach((hotkey) => {
             el.createEl('kbd', {
                 cls: 'suggestion-hotkey',
-                text: generateHotKeyText(hotkey, this.plugin.settings.hyperKeyOverride),
+                text: generateHotKeyText(hotkey, this.plugin.settings),
             });
         });
     }

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -2,9 +2,9 @@ import {
     App, Instruction, normalizePath, TFile,
 } from 'obsidian';
 import {
-    MODIFIER_ICONS,
+    generateHotKeyText,
     OrderedSet,
-    PaletteMatch, SPECIAL_KEYS, SuggestModalAdapter,
+    PaletteMatch, SuggestModalAdapter,
 } from 'src/utils';
 import { Match, UnsafeAppInterface } from 'src/types/types';
 import BetterCommandPalettePlugin from 'src/main';
@@ -55,11 +55,11 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
 
     getInstructions(): Instruction[] {
         return [
-            { command: SPECIAL_KEYS.ENTER, purpose: 'Open file' },
-            { command: `${MODIFIER_ICONS.Shift} ${SPECIAL_KEYS.ENTER}`, purpose: 'Open file in new pane' },
-            { command: `${MODIFIER_ICONS.Meta} ${SPECIAL_KEYS.ENTER}`, purpose: 'Create file' },
-            { command: `${MODIFIER_ICONS.Meta} ${MODIFIER_ICONS.Shift} ${SPECIAL_KEYS.ENTER}`, purpose: 'Create file in new pane' },
-            { command: `${SPECIAL_KEYS.ESC}`, purpose: 'Close palette' },
+            { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file' },
+            { command: generateHotKeyText({ modifiers: ['Shift'], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file in new pane' },
+            { command: generateHotKeyText({ modifiers: ['Mod'], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file' },
+            { command: generateHotKeyText({ modifiers: ['Mod', 'Shift'], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file in new pane' },
+            { command: generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings), purpose: 'Close palette' },
         ];
     }
 

--- a/src/palette-modal-adapters/tag-adapter.ts
+++ b/src/palette-modal-adapters/tag-adapter.ts
@@ -1,6 +1,7 @@
 import { Instruction } from 'obsidian';
 import {
-    PaletteMatch, SPECIAL_KEYS, SuggestModalAdapter,
+    generateHotKeyText,
+    PaletteMatch, SuggestModalAdapter,
 }
     from 'src/utils';
 import { Match, UnsafeAppInterface } from '../types/types';
@@ -38,8 +39,8 @@ export default class BetterCommandPaletteTagAdapter extends SuggestModalAdapter 
 
     getInstructions(): Instruction[] {
         return [
-            { command: SPECIAL_KEYS.ENTER, purpose: 'Open file' },
-            { command: `${SPECIAL_KEYS.ESC}`, purpose: 'Close palette' },
+            { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file' },
+            { command: generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings), purpose: 'Close Palette' },
         ];
     }
 

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -116,18 +116,18 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             closeModal(event);
         });
 
-        this.scope.register(['Meta'], 'Backspace', (event: KeyboardEvent) => {
+        this.scope.register(['Mod'], 'Backspace', (event: KeyboardEvent) => {
             closeModal(event);
         });
 
-        this.scope.register(['Meta'], 'Enter', (event: KeyboardEvent) => {
+        this.scope.register(['Mod'], 'Enter', (event: KeyboardEvent) => {
             if (this.actionType === this.ACTION_TYPE_FILES) {
                 this.currentAdapter.onChooseSuggestion(null, event);
                 this.close();
             }
         });
 
-        this.scope.register(['Meta', 'Shift'], 'Enter', (event: KeyboardEvent) => {
+        this.scope.register(['Mod', 'Shift'], 'Enter', (event: KeyboardEvent) => {
             if (this.actionType === this.ACTION_TYPE_FILES) {
                 this.currentAdapter.onChooseSuggestion(null, event);
                 this.close();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,7 +2,7 @@ import {
     App, Command, PluginSettingTab, setIcon, Setting,
 } from 'obsidian';
 import BetterCommandPalettePlugin from 'src/main';
-import { MacroCommandInterface, UnsafeAppInterface } from './types/types';
+import { HotkeyStyleType, MacroCommandInterface, UnsafeAppInterface } from './types/types';
 import { SettingsCommandSuggestModal } from './utils';
 
 export interface BetterCommandPalettePluginSettings {
@@ -12,7 +12,8 @@ export interface BetterCommandPalettePluginSettings {
     suggestionLimit: number,
     recentAbovePinned: boolean,
     hyperKeyOverride: boolean,
-    macros: MacroCommandInterface[]
+    macros: MacroCommandInterface[],
+    hotkeyStyle: HotkeyStyleType;
 }
 
 export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
@@ -23,6 +24,7 @@ export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
     recentAbovePinned: false,
     hyperKeyOverride: false,
     macros: [],
+    hotkeyStyle: 'auto',
 };
 
 export class BetterCommandPaletteSettingTab extends PluginSettingTab {
@@ -104,6 +106,19 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
                 .setValue(settings.suggestionLimit.toString())
                 .onChange(async (v) => {
                     settings.suggestionLimit = parseInt(v, 10);
+                    await this.plugin.saveSettings();
+                }));
+
+        new Setting(containerEl)
+            .setName('Hotkey Modifier Style')
+            .setDesc('Allows autodetecting of hotkey modifier or forcing to Mac or Windows')
+            .addDropdown((d) => d.addOptions({
+                auto: 'Auto Detect',
+                mac: 'Force Mac Hotkeys',
+                windows: 'Force Windows Hotkeys',
+            }).setValue(settings.hotkeyStyle)
+                .onChange(async (v) => {
+                    settings.hotkeyStyle = v as HotkeyStyleType;
                     await this.plugin.saveSettings();
                 }));
 

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -63,3 +63,5 @@ export interface UnsafeAppInterface extends App {
         getPluginById(id: string): { instance: { options: { pinned: [] } } },
     }
 }
+
+type HotkeyStyleType = 'auto' | 'mac' | 'windows';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,12 +4,12 @@ import { BetterCommandPalettePluginSettings } from 'src/settings';
 const HYPER_KEY_MODIFIERS_SET = new Set(['Alt', 'Ctrl', 'Mod', 'Shift']);
 
 const BASIC_MODIFIER_ICONS = {
-    Mod: 'Ctrl',
-    Ctrl: 'Ctrl',
-    Meta: 'Win',
-    Alt: 'Alt',
-    Shift: 'Shift',
-    Hyper: 'Caps',
+    Mod: 'Ctrl +',
+    Ctrl: 'Ctrl +',
+    Meta: 'Win +',
+    Alt: 'Alt +',
+    Shift: 'Shift +',
+    Hyper: 'Caps +',
 };
 
 const MAC_MODIFIER_ICONS = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,8 +1,18 @@
-import { Hotkey, Modifier } from 'obsidian';
+import { Hotkey, Modifier, Platform } from 'obsidian';
+import { BetterCommandPalettePluginSettings } from 'src/settings';
 
 const HYPER_KEY_MODIFIERS_SET = new Set(['Alt', 'Ctrl', 'Mod', 'Shift']);
 
-export const MODIFIER_ICONS = {
+const BASIC_MODIFIER_ICONS = {
+    Mod: 'Ctrl',
+    Ctrl: 'Ctrl',
+    Meta: 'Win',
+    Alt: 'Alt',
+    Shift: 'Shift',
+    Hyper: 'Caps',
+};
+
+const MAC_MODIFIER_ICONS = {
     Mod: '⌘',
     Ctrl: '^',
     Meta: '⌘',
@@ -10,6 +20,8 @@ export const MODIFIER_ICONS = {
     Shift: '⇧',
     Hyper: '⇪',
 };
+
+export const MODIFIER_ICONS = Platform.isMacOS ? MAC_MODIFIER_ICONS : BASIC_MODIFIER_ICONS;
 
 export const SPECIAL_KEYS : Record<string, string> = {
     TAB: '↹',
@@ -42,14 +54,25 @@ function isHyperKey(modifiers: Modifier[]) : boolean {
  * @param {Hotkey} hotkey The hotkey to generate text for
  * @returns {string} The hotkey text
  */
-export function generateHotKeyText(hotkey: Hotkey, useHyperKey: boolean = false): string {
+export function generateHotKeyText(
+    hotkey: Hotkey,
+    settings: BetterCommandPalettePluginSettings,
+): string {
+    let modifierIcons = MODIFIER_ICONS;
+
+    if (settings.hotkeyStyle === 'mac') {
+        modifierIcons = MAC_MODIFIER_ICONS;
+    } else if (settings.hotkeyStyle === 'windows') {
+        modifierIcons = BASIC_MODIFIER_ICONS;
+    }
+
     const hotKeyStrings: string[] = [];
 
-    if (useHyperKey && isHyperKey(hotkey.modifiers)) {
-        hotKeyStrings.push(MODIFIER_ICONS.Hyper);
+    if (settings.hyperKeyOverride && isHyperKey(hotkey.modifiers)) {
+        hotKeyStrings.push(modifierIcons.Hyper);
     } else {
         hotkey.modifiers.forEach((mod: Modifier) => {
-            hotKeyStrings.push(MODIFIER_ICONS[mod]);
+            hotKeyStrings.push(modifierIcons[mod]);
         });
     }
 


### PR DESCRIPTION
1. Adds window style hotkey modifiers
2. Autodetects the OS and uses the correct modifier style
3. Adds a setting to override the autodetection to whatever style you prefer
4. Refactors existing code to use `Mod` instead of `Meta` as I believe that is the more appropriate key since `Meta` maps to the windows key which is not common behavior.