### PR TITLE
[Issue 32] Add file aliases to the file search palette

### DIFF
--- a/src/palette-modal-adapters/tag-adapter.ts
+++ b/src/palette-modal-adapters/tag-adapter.ts
@@ -49,7 +49,7 @@ export default class BetterCommandPaletteTagAdapter extends SuggestModalAdapter 
 
         const count = parseInt(match.tags[0], 10);
 
-        el.createEl('span', {
+        el.createEl('div', {
             cls: 'suggestion-sub-content',
             text: `Found in ${count} file${count === 1 ? '' : 's'}`,
         });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,9 +10,17 @@
         float: right;
     }
 
+
+
     .suggestion-sub-content {
         color: var(--text-faint);
-        display: block;
+
+        .suggestion-sub-content-alias {
+            display: inline-flex;
+            align-items: center;
+            margin-right: 10px;
+            color: var(--text-muted);
+        }
     }
 
     .unresolved {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,7 +3,8 @@ import {
     Command, Hotkey, Modifier, normalizePath, Platform, TFile,
 } from 'obsidian';
 import { BetterCommandPalettePluginSettings } from 'src/settings';
-import { Match } from 'src/types/types';
+import { Match, UnsafeMetadataCacheInterface } from 'src/types/types';
+import PaletteMatch from './palette-match';
 import OrderedSet from './ordered-set';
 import {
     BASIC_MODIFIER_ICONS, HYPER_KEY_MODIFIERS_SET, MAC_MODIFIER_ICONS, SPECIAL_KEYS,
@@ -122,4 +123,26 @@ export function matchTag(tags: string[], tagQueries: string[]): boolean {
         }
     }
     return false;
+}
+
+export function createPaletteMatchFromFilePath(
+    metadataCache: UnsafeMetadataCacheInterface,
+    filePath: string,
+): PaletteMatch {
+    // Get the cache item for the file so that we can extract its tags
+    const fileCache = metadataCache.getCache(filePath);
+
+    // Sometimes the cache keeps files that have been deleted
+    if (!fileCache) return null;
+
+    const tags = (fileCache.tags || []).map((tc) => tc.tag);
+
+    const aliases = (fileCache?.frontmatter?.aliases || []).join(':');
+
+    // Make the palette match
+    return new PaletteMatch(
+        filePath,
+        `${filePath}:${aliases}`, // Concat our aliases and path to make searching easy
+        tags,
+    );
 }


### PR DESCRIPTION
1. Add file aliases to the searched string
2. Adds the file aliases to the sub-component when rendering