### PR TITLE
[Issue 32] Make file aliases new suggestions

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,17 +10,18 @@
         float: right;
     }
 
+    .suggestion-content {
+        display: inline-flex;
+        align-items: center;
+
+        svg {
+            margin-right: 5px;
+        }
+    }
 
 
     .suggestion-sub-content {
         color: var(--text-faint);
-
-        .suggestion-sub-content-alias {
-            display: inline-flex;
-            align-items: center;
-            margin-right: 10px;
-            color: var(--text-muted);
-        }
     }
 
     .unresolved {

--- a/src/utils/ordered-set.ts
+++ b/src/utils/ordered-set.ts
@@ -22,6 +22,10 @@ export default class OrderedSet<T extends Comparable> {
         return this.map.set(item.value(), item);
     }
 
+    addAll(items: T[]) {
+        items.forEach((item) => this.add(item));
+    }
+
     delete(item: T) {
         this.map.delete(item.value());
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -125,24 +125,31 @@ export function matchTag(tags: string[], tagQueries: string[]): boolean {
     return false;
 }
 
-export function createPaletteMatchFromFilePath(
+export function createPaletteMatchesFromFilePath(
     metadataCache: UnsafeMetadataCacheInterface,
     filePath: string,
-): PaletteMatch {
+): PaletteMatch[] {
     // Get the cache item for the file so that we can extract its tags
     const fileCache = metadataCache.getCache(filePath);
 
     // Sometimes the cache keeps files that have been deleted
-    if (!fileCache) return null;
+    if (!fileCache) return [];
 
     const tags = (fileCache.tags || []).map((tc) => tc.tag);
 
-    const aliases = (fileCache?.frontmatter?.aliases || []).join(':');
+    const aliases = fileCache?.frontmatter?.aliases || [];
 
     // Make the palette match
-    return new PaletteMatch(
-        filePath,
-        `${filePath}:${aliases}`, // Concat our aliases and path to make searching easy
-        tags,
-    );
+    return [
+        new PaletteMatch(
+            filePath,
+            filePath, // Concat our aliases and path to make searching easy
+            tags,
+        ),
+        ...aliases.map((alias: string) => new PaletteMatch(
+            `${alias}:${filePath}`,
+            alias,
+            tags,
+        )),
+    ];
 }


### PR DESCRIPTION
1. Reworks file aliases to be separate suggestions in the dropdown
2. Adds a hover tooltip to show which file the alias is for
3. Add icon to show which items are aliases
4. Does not add aliases to the recently used set
5. Ended up not being used in this PR, but also added an `addAll` to the `OrderedSet`