### PR TITLE
[Issue 32] Show file path for alias

### DIFF
--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -52,7 +52,7 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         this.allItems = this.allItems.concat(Array.from(this.unresolvedItems.values())).reverse();
 
         // Use obsidian's last open files as the previous items
-        this.app.workspace.getLastOpenFiles().reverse().forEach((filePath) => {
+        [...this.app.workspace.getLastOpenFiles()].reverse().forEach((filePath) => {
             const matches = createPaletteMatchesFromFilePath(this.app.metadataCache, filePath);
 
             // For previous items we only want the actual file, not any aliases
@@ -78,21 +78,29 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
     }
 
     renderSuggestion(match: Match, el: HTMLElement): void {
-        const suggestionEl = el.createEl('span', {
+        const suggestionEl = el.createEl('div', {
             cls: 'suggestion-content',
+            text: match.text,
         });
-
-        if (match.id.includes(':')) {
-            setIcon(suggestionEl, 'forward-arrow');
-
-            const [, path] = match.id.split(':');
-            suggestionEl.ariaLabel = `Alias for: ${path}`;
-        }
-
-        suggestionEl.appendText(match.text);
 
         if (this.unresolvedItems.has(match)) {
             suggestionEl.addClass('unresolved');
+        }
+
+        if (match.id.includes(':')) {
+            // Set Icon will destroy the first element in a node. So we need to add one back
+            suggestionEl.createEl('div', {
+                cls: 'suggestion-name',
+                text: match.text,
+            }).ariaLabel = 'Alias';
+
+            setIcon(suggestionEl, 'right-arrow-with-tail');
+
+            const [, path] = match.id.split(':');
+            suggestionEl.createEl('div', {
+                cls: 'suggestion-description',
+                text: path,
+            });
         }
 
         el.createEl('div', {

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -37,13 +37,13 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         this.unresolvedItems = new OrderedSet<Match>();
 
         // Actually returns all files in the cache even if there are no unresolved links
-        Object.entries(this.app.metadataCache.unresolvedLinks)
-            .forEach(([filePath, linkObject]: [string, Record<string, number>]) => {
+        this.app.metadataCache.getCachedFiles()
+            .forEach((filePath: string) => {
                 const matches = createPaletteMatchesFromFilePath(this.app.metadataCache, filePath);
                 this.allItems = this.allItems.concat(matches);
 
                 // Add any unresolved links to the set
-                Object.keys(linkObject).forEach(
+                Object.keys(this.app.metadataCache.unresolvedLinks[filePath]).forEach(
                     (p) => this.unresolvedItems.add(new PaletteMatch(p, p)),
                 );
             });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,8 +15,14 @@
         align-items: center;
 
         svg {
-            margin-right: 5px;
+            margin: 0px 5px;
+            color: var(--text-muted);
         }
+    }
+
+    .suggestion-description {
+        display: inline;
+        color: var(--text-muted);
     }
 
 
@@ -29,8 +35,8 @@
 
         &::after {
             content: '(Unresolved link)';
-            float: right;
             color: var(--text-faint);
+            margin-left: 10px;
         }
     }
 }


### PR DESCRIPTION
1. Shows the file paths for aliases without needing to hover
2. fixes a bug where the alias of a file could take a long time to populate the dropdown