### PR TITLE
Fix single alias key

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import {
     App,
-    Command, Hotkey, Modifier, normalizePath, Platform, TFile,
+    Command, Hotkey, Modifier, normalizePath, parseFrontMatterAliases, Platform, TFile,
 } from 'obsidian';
 import { BetterCommandPalettePluginSettings } from 'src/settings';
 import { Match, UnsafeMetadataCacheInterface } from 'src/types/types';
@@ -137,7 +137,7 @@ export function createPaletteMatchesFromFilePath(
 
     const tags = (fileCache.tags || []).map((tc) => tc.tag);
 
-    const aliases = fileCache?.frontmatter?.aliases || [];
+    const aliases = parseFrontMatterAliases(fileCache.frontmatter) || [];
 
     // Make the palette match
     return [

--- a/test/e2e/test-utils.ts
+++ b/test/e2e/test-utils.ts
@@ -109,17 +109,21 @@ export class TestCase {
         const el = this.findElInternal(selector)() as HTMLInputElement;
 
         if (el.isContentEditable) {
-            if (window.getSelection) {
-                const sel = window.getSelection();
-                if (sel.getRangeAt && sel.rangeCount) {
-                    const range = sel.getRangeAt(0);
-                    if (clearCurrentText) {
-                        range.deleteContents();
-                    }
-                    range.collapse(false);
-                    range.insertNode(document.createTextNode(text));
-                    range.collapse(false);
+            const sel = window.getSelection();
+            if (sel.getRangeAt && sel.rangeCount) {
+                const selection = window.getSelection();
+                const range = document.createRange();
+                range.selectNodeContents(el);
+                selection.removeAllRanges();
+                selection.addRange(range);
+
+                if (clearCurrentText) {
+                    range.deleteContents();
                 }
+
+                range.collapse(false);
+                range.insertNode(document.createTextNode(text));
+                range.collapse(false);
             }
         } else {
             if (clearCurrentText) {

--- a/test/e2e/tests/initialize-test-env.ts
+++ b/test/e2e/tests/initialize-test-env.ts
@@ -19,14 +19,19 @@ testCase.addTest('Create test file', async () => {
     await testCase.findEl('.nav-file-title-content', { text: 'e2e-test-file' });
 });
 
+testCase.addTest('Add Frontmatter', async () => {
+    await testCase.clickEl('.cm-content');
+    await testCase.typeInEl('.cm-content', '---\nalias: [e2e-alias-1]\n---');
+});
+
 testCase.addTest('Add Links', async () => {
     await testCase.clickEl('.cm-content');
-    await testCase.typeInEl('.cm-content', '[[e2e-test-folder/e2e-unresolved-link]]');
+    await testCase.typeInEl('.cm-content', '\n[[e2e-test-folder/e2e-unresolved-link]]');
 });
 
 testCase.addTest('Add tags', async () => {
-    await testCase.typeInEl('.cm-content', ' #e2e-tag ');
-    await testCase.typeInEl('.cm-content', ' #e2e-tag/e2e-nested-tag ');
+    await testCase.typeInEl('.cm-content', '\n#e2e-tag ');
+    await testCase.typeInEl('.cm-content', '\n#e2e-tag/e2e-nested-tag ');
 });
 
 export default testCase;

--- a/test/e2e/tests/test-file-palette.ts
+++ b/test/e2e/tests/test-file-palette.ts
@@ -39,6 +39,11 @@ testCase.addTest('Create file from unresolved link', async () => {
     await testCase.findEl('.view-header-title', { text: 'e2e-unresolved-link' });
 });
 
+testCase.addTest('Add alias to file', async () => {
+    await testCase.clickEl('.cm-content');
+    await testCase.typeInEl('.cm-content', '---\naliases: [e2e-alias-2]\n---');
+});
+
 testCase.addTest('Recent files bubble up', async () => {
     await testCase.pressKey('O', { metaKey: true });
 
@@ -93,7 +98,7 @@ testCase.addTest('Search normal tag', async () => {
     await testCase.assertElCount('.suggestion-item', 20);
 
     await testCase.typeInEl('.prompt-input', '@#e2e-tag');
-    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.assertElCount('.suggestion-item', 2);
     await testCase.findEl('.suggestion-item', { text: 'e2e-test-file' });
 
     await testCase.pressKey('Enter', { selector: '.prompt-input' });
@@ -104,10 +109,34 @@ testCase.addTest('Search nested tag', async () => {
     await testCase.assertElCount('.suggestion-item', 20);
 
     await testCase.typeInEl('.prompt-input', '@#e2e-tag/e2e-nested-tag');
-    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.assertElCount('.suggestion-item', 2);
     await testCase.findEl('.suggestion-item', { text: 'e2e-test-file' });
 
     await testCase.pressKey('Enter', { selector: '.prompt-input' });
+});
+
+testCase.addTest('Search alias (singular)', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.assertElCount('.suggestion-item', 20);
+
+    await testCase.typeInEl('.prompt-input', 'e2e-alias-1');
+    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.findEl('.suggestion-item', { text: 'e2e-alias-1' });
+    await testCase.findEl('.suggestion-item', { text: 'e2e-test-file' });
+
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Search aliases (plural)', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.assertElCount('.suggestion-item', 20);
+
+    await testCase.typeInEl('.prompt-input', 'e2e-alias-2');
+    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.findEl('.suggestion-item', { text: 'e2e-alias-2' });
+    await testCase.findEl('.suggestion-item', { text: 'e2e-unresolved-link' });
+
+    await testCase.pressKey('Esc');
 });
 
 export default testCase;

--- a/test/e2e/tests/test-tag-palette.ts
+++ b/test/e2e/tests/test-tag-palette.ts
@@ -22,7 +22,7 @@ testCase.addTest('Tag selection opens file search', async () => {
     await testCase.pressKey('Enter');
     await testCase.assertElCount('.better-command-palette', 1);
     await testCase.findEl('.better-command-palette-title', { text: 'Files' });
-    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.assertElCount('.suggestion-item', 2);
     await testCase.pressKey('Esc');
 });
 


### PR DESCRIPTION
1. Uses the util to parse frontmatter instead of doing it manually. This means it will parse both `alias` and `aliases`
2. Adds unit tests for these