### PR TITLE
[Issue-38] Add Frontmatter Tags

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import {
-    App,
-    Command, Hotkey, Modifier, normalizePath, parseFrontMatterAliases, Platform, TFile,
+    App, Command, Hotkey, Modifier, normalizePath, parseFrontMatterAliases,
+    parseFrontMatterTags, Platform, TFile,
 } from 'obsidian';
 import { BetterCommandPalettePluginSettings } from 'src/settings';
 import { Match, UnsafeMetadataCacheInterface } from 'src/types/types';
@@ -135,7 +135,9 @@ export function createPaletteMatchesFromFilePath(
     // Sometimes the cache keeps files that have been deleted
     if (!fileCache) return [];
 
-    const tags = (fileCache.tags || []).map((tc) => tc.tag);
+    const cacheTags = (fileCache.tags || []).map((tc) => tc.tag);
+    const frontmatterTags = parseFrontMatterTags(fileCache.frontmatter) || [];
+    const tags = cacheTags.concat(frontmatterTags);
 
     const aliases = parseFrontMatterAliases(fileCache.frontmatter) || [];
 

--- a/test/e2e/tests/initialize-test-env.ts
+++ b/test/e2e/tests/initialize-test-env.ts
@@ -21,7 +21,7 @@ testCase.addTest('Create test file', async () => {
 
 testCase.addTest('Add Frontmatter', async () => {
     await testCase.clickEl('.cm-content');
-    await testCase.typeInEl('.cm-content', '---\nalias: [e2e-alias-1]\n---');
+    await testCase.typeInEl('.cm-content', '---\nalias: [e2e-alias-1]\ntags: [e2e-frontmatter-tag]\n---');
 });
 
 testCase.addTest('Add Links', async () => {

--- a/test/e2e/tests/test-file-palette.ts
+++ b/test/e2e/tests/test-file-palette.ts
@@ -115,6 +115,17 @@ testCase.addTest('Search nested tag', async () => {
     await testCase.pressKey('Enter', { selector: '.prompt-input' });
 });
 
+testCase.addTest('Search frontmatter tag', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.assertElCount('.suggestion-item', 20);
+
+    await testCase.typeInEl('.prompt-input', '@#e2e-frontmatter-tag');
+    await testCase.assertElCount('.suggestion-item', 2);
+    await testCase.findEl('.suggestion-item', { text: 'e2e-test-file' });
+
+    await testCase.pressKey('Enter', { selector: '.prompt-input' });
+});
+
 testCase.addTest('Search alias (singular)', async () => {
     await testCase.pressKey('O', { metaKey: true });
     await testCase.assertElCount('.suggestion-item', 20);

--- a/test/e2e/tests/test-tag-palette.ts
+++ b/test/e2e/tests/test-tag-palette.ts
@@ -9,10 +9,19 @@ testCase.addTest('Open, search, and close', async () => {
     await testCase.assertElCount('.suggestion-item', 20);
 
     await testCase.typeInEl('.prompt-input', 'e2e-tag');
-    await testCase.assertElCount('.suggestion-item', 2);
+    await testCase.assertElCount('.suggestion-item', 3);
 
     await testCase.pressKey('Esc');
     await testCase.assertElCount('.better-command-palette', 0);
+});
+
+testCase.addTest('Finds frontmatter tags', async () => {
+    await testCase.pressKey('T', { metaKey: true });
+
+    await testCase.typeInEl('.prompt-input', 'e2e-frontmatter-tag');
+    await testCase.assertElCount('.suggestion-item', 1);
+
+    await testCase.pressKey('Esc');
 });
 
 testCase.addTest('Tag selection opens file search', async () => {


### PR DESCRIPTION
* Concats the tags from the file cache with the tags from the frontmatter block when creating file matches
* Adds basic tests for frontmatter tags