### PR TITLE
[Issue-35] Setting to switch file creation hotkeys

### DIFF
--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -63,11 +63,13 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
     }
 
     getInstructions(): Instruction[] {
+        const { createNewPaneMod, createNewFileMod } = this.plugin.settings;
+
         return [
             { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file' },
-            { command: generateHotKeyText({ modifiers: ['Shift'], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file in new pane' },
-            { command: generateHotKeyText({ modifiers: ['Mod'], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file' },
-            { command: generateHotKeyText({ modifiers: ['Mod', 'Shift'], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file in new pane' },
+            { command: generateHotKeyText({ modifiers: [createNewPaneMod], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file in new pane' },
+            { command: generateHotKeyText({ modifiers: [createNewFileMod], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file' },
+            { command: generateHotKeyText({ modifiers: [createNewFileMod, createNewPaneMod], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file in new pane' },
             { command: generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings), purpose: 'Close palette' },
             { command: generateHotKeyText({ modifiers: [], key: 'BACKSPACE' }, this.plugin.settings), purpose: 'Search Commands' },
             { command: this.plugin.settings.tagSearchPrefix, purpose: 'Search Tags' },
@@ -130,6 +132,6 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
             this.getPrevItems().add(match || new PaletteMatch(file.path, file.path));
         }
 
-        openFileWithEventKeys(this.app, file, event);
+        openFileWithEventKeys(this.app, this.plugin.settings, file, event);
     }
 }

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -124,6 +124,8 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             }
         };
 
+        const { createNewPaneMod, createNewFileMod } = plugin.settings;
+
         this.scope.register([], 'Backspace', (event: KeyboardEvent) => {
             closeModal(event);
         });
@@ -132,21 +134,21 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             closeModal(event);
         });
 
-        this.scope.register(['Mod'], 'Enter', (event: KeyboardEvent) => {
+        this.scope.register([createNewFileMod], 'Enter', (event: KeyboardEvent) => {
             if (this.actionType === this.ACTION_TYPE_FILES) {
                 this.currentAdapter.onChooseSuggestion(null, event);
                 this.close(event);
             }
         });
 
-        this.scope.register(['Mod', 'Shift'], 'Enter', (event: KeyboardEvent) => {
+        this.scope.register([createNewFileMod, createNewPaneMod], 'Enter', (event: KeyboardEvent) => {
             if (this.actionType === this.ACTION_TYPE_FILES) {
                 this.currentAdapter.onChooseSuggestion(null, event);
                 this.close(event);
             }
         });
 
-        this.scope.register(['Shift'], 'Enter', (event: KeyboardEvent) => {
+        this.scope.register([createNewPaneMod], 'Enter', (event: KeyboardEvent) => {
             if (this.actionType === this.ACTION_TYPE_FILES && this.currentSuggestions.length) {
                 this.currentAdapter.onChooseSuggestion(this.currentSuggestions[0], event);
                 this.close(event);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 import {
-    App, Command, PluginSettingTab, setIcon, Setting,
+    App, Command, Modifier, PluginSettingTab, setIcon, Setting,
 } from 'obsidian';
 import BetterCommandPalettePlugin from 'src/main';
 import { HotkeyStyleType, MacroCommandInterface, UnsafeAppInterface } from './types/types';
@@ -14,6 +14,8 @@ export interface BetterCommandPalettePluginSettings {
     hyperKeyOverride: boolean,
     macros: MacroCommandInterface[],
     hotkeyStyle: HotkeyStyleType;
+    createNewFileMod: Modifier,
+    createNewPaneMod: Modifier,
 }
 
 export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
@@ -25,6 +27,8 @@ export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
     hyperKeyOverride: false,
     macros: [],
     hotkeyStyle: 'auto',
+    createNewFileMod: 'Mod',
+    createNewPaneMod: 'Shift',
 };
 
 export class BetterCommandPaletteSettingTab extends PluginSettingTab {
@@ -71,6 +75,15 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
             .setDesc('For those users who have use a "Hyper Key", enabling this maps the icons "⌥ ^ ⌘ ⇧" to the caps lock icon "⇪" ')
             .addToggle((t) => t.setValue(settings.hyperKeyOverride).onChange(async (val) => {
                 settings.hyperKeyOverride = val;
+                await this.plugin.saveSettings();
+            }));
+
+        new Setting(containerEl)
+            .setName('Use shift to create files and cmd to open in new panes')
+            .setDesc('By default cmd is used to create files and shift is used to open in new panes. This setting reverses that to mimic the functionality of the standard quick switcher')
+            .addToggle((t) => t.setValue(settings.createNewFileMod === 'Shift').onChange(async (val) => {
+                settings.createNewFileMod = val ? 'Shift' : 'Mod';
+                settings.createNewPaneMod = val ? 'Mod' : 'Shift';
                 await this.plugin.saveSettings();
             }));
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -91,6 +91,7 @@ export async function getOrCreateFile(app: App, path: string) : Promise < TFile 
 
 export function openFileWithEventKeys(
     app: App,
+    settings: BetterCommandPalettePluginSettings,
     file: TFile,
     event: MouseEvent | KeyboardEvent,
 ) {
@@ -98,8 +99,10 @@ export function openFileWithEventKeys(
 
     let leaf = workspace.activeLeaf;
 
+    const createNewPane = settings.createNewPaneMod === 'Shift' ? event.shiftKey : event.metaKey;
+
     // Shift key means we should be using a new leaf
-    if (event.shiftKey) {
+    if (createNewPane) {
         leaf = workspace.createLeafBySplit(workspace.activeLeaf);
         workspace.setActiveLeaf(leaf);
     }

--- a/test/e2e/tests/test-file-palette.ts
+++ b/test/e2e/tests/test-file-palette.ts
@@ -150,4 +150,66 @@ testCase.addTest('Search aliases (plural)', async () => {
     await testCase.pressKey('Esc');
 });
 
+testCase.addTest('Switch new pane and file creation modifiers', async () => {
+    await testCase.pressKey(',', { metaKey: true });
+    await testCase.clickEl('.vertical-tab-nav-item', { text: 'Better Command Palette' });
+
+    try {
+        await testCase.findEl('.setting-item:nth-child(5) .checkbox-container.is-enabled');
+    } catch (e) {
+        await testCase.clickEl('.setting-item:nth-child(5) .checkbox-container');
+    }
+
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Open file in new pane', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+
+    await testCase.typeInEl('.prompt-input', 'e2e-test-file');
+    await testCase.pressKey('Enter', { metaKey: true, selector: '.prompt-input' });
+
+    await testCase.assertElCount('.view-header-title', 2);
+
+    await testCase.clickEl('.mod-close-leaf');
+    await testCase.clickEl('.mod-close-leaf');
+});
+
+testCase.addTest('Create arbitrary file', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+
+    await testCase.typeInEl('.prompt-input', 'e2e-test-folder/e2e-test-file-4');
+    await testCase.pressKey('Enter', { shiftKey: true, selector: '.prompt-input' });
+
+    await testCase.assertElCount('.view-header-title', 1);
+    await testCase.findEl('.view-header-title', { text: 'e2e-test-file-4' });
+});
+
+testCase.addTest('Create arbitrary file in new pane', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+
+    await testCase.typeInEl('.prompt-input', 'e2e-test-folder/e2e-test-file-5');
+    await testCase.pressKey('Enter', { shiftKey: true, metaKey: true, selector: '.prompt-input' });
+
+    await testCase.assertElCount('.view-header-title', 2);
+    await testCase.findEl('.view-header-title', { text: 'e2e-test-file-4' });
+    await testCase.findEl('.view-header-title', { text: 'e2e-test-file-5' });
+
+    await testCase.clickEl('.mod-close-leaf');
+    await testCase.clickEl('.mod-close-leaf');
+});
+
+testCase.addTest('Switch new pane and file creation modifiers back to default', async () => {
+    await testCase.pressKey(',', { metaKey: true });
+    await testCase.clickEl('.vertical-tab-nav-item', { text: 'Better Command Palette' });
+
+    try {
+        await testCase.findEl('.setting-item:nth-child(5) .checkbox-container:not(.is-enabled)');
+    } catch (e) {
+        await testCase.clickEl('.setting-item:nth-child(5) .checkbox-container');
+    }
+
+    await testCase.pressKey('Esc');
+});
+
 export default testCase;


### PR DESCRIPTION
* Adds a new setting to switch the functionality of the `cmd` and `shift` keys when in the file palette. Enabling the setting makes the palette function like the standard quick switcher.
* Adds tests for this new setting