### PR TITLE
[Issue-36] Hide commands, files, and tags

### DIFF
--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -48,12 +48,8 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
     }
 
     getInstructions(): Instruction[] {
-        const backspaceHotkeyText = generateHotKeyText({ modifiers: [], key: 'BACKSPACE' }, this.plugin.settings);
-        const escapeHotkeyText = generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings);
-
         return [
             { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Run command' },
-            { command: `${backspaceHotkeyText} / ${escapeHotkeyText}`, purpose: 'Close palette' },
             { command: this.plugin.settings.fileSearchPrefix, purpose: 'Search Files' },
             { command: this.plugin.settings.tagSearchPrefix, purpose: 'Search Tags' },
         ];

--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -24,6 +24,9 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
         this.titleText = 'Better Command Palette: Commands';
         this.emptyStateText = 'No matching commands.';
 
+        this.hiddenIds = this.plugin.settings.hiddenCommands;
+        this.hiddenIdsSettingsKey = 'hiddenCommands';
+
         this.allItems = this.app.commands.listCommands()
             .sort((a: Command, b: Command) => b.name.localeCompare(a.name))
             .map((c: Command): Match => new PaletteMatch(c.id, c.name));
@@ -68,9 +71,10 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
         const hotkeys = customHotkeys || defaultHotkeys || [];
 
         if (this.getPinnedItems().find((i) => i.id === match.id)) {
-            const flairContainer = el.createEl('span', 'suggestion-flair');
-            // 13 copied from current command palette
+            const flairContainer = el.querySelector('.suggestion-flair') as HTMLElement;
             setIcon(flairContainer, 'filled-pin', 13);
+            flairContainer.ariaLabel = 'Pinned';
+            flairContainer.onClickEvent(() => {});
         }
 
         let { text } = match;

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -72,8 +72,6 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
             { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file' },
             { command: generateHotKeyText({ modifiers: [createNewPaneMod], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file in new pane' },
             { command: generateHotKeyText({ modifiers: [createNewFileMod], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file' },
-            { command: generateHotKeyText({ modifiers: [createNewFileMod, createNewPaneMod], key: 'ENTER' }, this.plugin.settings), purpose: 'Create file in new pane' },
-            { command: generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings), purpose: 'Close palette' },
             { command: generateHotKeyText({ modifiers: [], key: 'BACKSPACE' }, this.plugin.settings), purpose: 'Search Commands' },
             { command: this.plugin.settings.tagSearchPrefix, purpose: 'Search Tags' },
         ];

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -32,6 +32,9 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         this.emptyStateText = 'No matching files.';
         this.fileSearchPrefix = this.plugin.settings.fileSearchPrefix;
 
+        this.hiddenIds = this.plugin.settings.hiddenFiles;
+        this.hiddenIdsSettingsKey = 'hiddenFiles';
+
         this.allItems = [];
 
         this.unresolvedItems = new OrderedSet<Match>();

--- a/src/palette-modal-adapters/tag-adapter.ts
+++ b/src/palette-modal-adapters/tag-adapter.ts
@@ -36,7 +36,6 @@ export default class BetterCommandPaletteTagAdapter extends SuggestModalAdapter 
     getInstructions(): Instruction[] {
         return [
             { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'See file usage' },
-            { command: generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings), purpose: 'Close Palette' },
             { command: generateHotKeyText({ modifiers: [], key: 'BACKSPACE' }, this.plugin.settings), purpose: 'Search Commands' },
             { command: this.plugin.settings.fileSearchPrefix, purpose: 'Search Files' },
         ];

--- a/src/palette-modal-adapters/tag-adapter.ts
+++ b/src/palette-modal-adapters/tag-adapter.ts
@@ -22,6 +22,9 @@ export default class BetterCommandPaletteTagAdapter extends SuggestModalAdapter 
     initialize(): void {
         super.initialize();
 
+        this.hiddenIds = this.plugin.settings.hiddenTags;
+        this.hiddenIdsSettingsKey = 'hiddenTags';
+
         this.tagSearchPrefix = this.plugin.settings.tagSearchPrefix;
         this.titleText = 'Better Command Palette: Tags';
         this.emptyStateText = 'No matching tags.';

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -329,18 +329,15 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
     renderSuggestion(match: Match, el: HTMLElement) {
         const isHidden = this.currentAdapter.hiddenIds.includes(match.id);
 
-        if (isHidden && !this.showHiddenItems) {
-            el.remove();
-            return;
+        if (isHidden) {
+            el.addClass('hidden');
         }
 
         renderPrevItems(match, el, this.currentAdapter.getPrevItems());
 
         const icon = 'cross';
 
-        const flairContainer = el.createEl('span', {
-            cls: ['suggestion-flair', ...(isHidden ? ['hidden'] : [])],
-        });
+        const flairContainer = el.createEl('span', 'suggestion-flair');
 
         setIcon(flairContainer, icon, 13);
         flairContainer.ariaLabel = isHidden ? 'Click to Unhide' : 'Click to Hide';

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -1,5 +1,6 @@
 import { App, setIcon, SuggestModal } from 'obsidian';
 import {
+    generateHotKeyText,
     OrderedSet, PaletteMatch, renderPrevItems, SuggestModalAdapter,
 } from 'src/utils';
 import { Match, UnsafeSuggestModalInterface } from 'src/types/types';
@@ -22,6 +23,8 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
     updateSuggestions: UnsafeSuggestModalInterface['updateSuggestions'];
 
+    plugin: BetterCommandPalettePlugin;
+
     actionType: number;
 
     fileSearchPrefix: string;
@@ -36,9 +39,9 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
     modalTitleEl: HTMLElement;
 
-    hiddenItemsEl: HTMLElement;
-
     hiddenItemsHeaderEl: HTMLElement;
+
+    showHiddenItems: boolean;
 
     initialInputValue: string;
 
@@ -67,6 +70,8 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.tagSearchPrefix = plugin.settings.tagSearchPrefix;
         this.suggestionLimit = plugin.settings.suggestionLimit;
         this.initialInputValue = initialInputValue;
+
+        this.plugin = plugin;
 
         this.modalEl.addClass('better-command-palette');
 
@@ -109,13 +114,11 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.modalEl.insertBefore(this.modalTitleEl, this.modalEl.firstChild);
 
         this.hiddenItemsHeaderEl = createEl('p', 'hidden-items-header');
-        this.hiddenItemsEl = createEl('div', { cls: ['hidden-items', 'collapsed'] });
+        this.showHiddenItems = false;
 
-        this.hiddenItemsHeaderEl.onClickEvent(() => {
-            this.hiddenItemsEl.toggleClass('collapsed', !this.hiddenItemsEl.hasClass('collapsed'));
-        });
+        this.hiddenItemsHeaderEl.onClickEvent(this.toggleHiddenItems);
+
         this.modalEl.insertBefore(this.hiddenItemsHeaderEl, this.resultContainerEl);
-        this.modalEl.insertBefore(this.hiddenItemsEl, this.resultContainerEl);
 
         // Set our scopes for the modal
         this.setScopes(plugin);
@@ -170,10 +173,13 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             }
         });
 
-        this.scope.register(['Mod'], 'I', () => {
-            this.hiddenItemsEl.toggleClass('collapsed', !this.hiddenItemsEl.hasClass('collapsed'));
-        });
+        this.scope.register(['Mod'], 'I', this.toggleHiddenItems);
     }
+
+    toggleHiddenItems = () => {
+        this.showHiddenItems = !this.showHiddenItems;
+        this.updateSuggestions();
+    };
 
     onOpen() {
         super.onOpen();
@@ -223,7 +229,9 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             this.updateEmptyStateText();
             this.updateTitleText();
             this.updateInstructions();
-            this.currentSuggestions = this.currentAdapter.getSortedItems();
+            this.currentSuggestions = this.currentAdapter
+                .getSortedItems()
+                .slice(0, this.suggestionLimit);
         }
 
         return wasUpdated;
@@ -243,7 +251,11 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
                 this.modalEl.removeChild(instruction);
             });
 
-        this.setInstructions(this.currentAdapter.getInstructions());
+        this.setInstructions([
+            ...this.currentAdapter.getInstructions(),
+            { command: generateHotKeyText({ modifiers: [], key: 'ESC' }, this.plugin.settings), purpose: 'Close palette' },
+            { command: generateHotKeyText({ modifiers: ['Mod'], key: 'I' }, this.plugin.settings), purpose: 'Toggle Hidden Items' },
+        ]);
     }
 
     getItems(): Match[] {
@@ -293,25 +305,46 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             this.getSuggestionsAsync(fixedQuery);
         }
 
-        // Clear out hidden items div
-        this.hiddenItemsHeaderEl.innerText = '';
-        this.hiddenItemsEl.empty();
+        const visibleItems = this.currentSuggestions.filter(
+            (match) => !this.currentAdapter.hiddenIds.includes(match.id),
+        );
+
+        const hiddenItemCount = this.currentSuggestions.length - visibleItems.length;
+
+        this.updateHiddenItemCountHeader(hiddenItemCount);
 
         // For now return what we currently have. We'll populate results later if we need to
-        return this.currentSuggestions;
+        return this.showHiddenItems ? this.currentSuggestions : visibleItems;
+    }
+
+    updateHiddenItemCountHeader(hiddenItemCount: number) {
+        this.hiddenItemsHeaderEl.empty();
+
+        if (hiddenItemCount !== 0) {
+            const text = `${this.showHiddenItems ? 'Hide' : 'Show'} hidden items (${hiddenItemCount})`;
+            this.hiddenItemsHeaderEl.setText(text);
+        }
     }
 
     renderSuggestion(match: Match, el: HTMLElement) {
+        const isHidden = this.currentAdapter.hiddenIds.includes(match.id);
+
+        if (isHidden && !this.showHiddenItems) {
+            el.remove();
+            return;
+        }
+
         renderPrevItems(match, el, this.currentAdapter.getPrevItems());
 
-        const isHidden = this.currentAdapter.hiddenIds.includes(match.id);
-        const icon = isHidden ? 'plus-with-circle' : 'minus-with-circle';
+        const icon = 'cross';
 
-        const flairContainer = el.createEl('span', 'suggestion-flair');
+        const flairContainer = el.createEl('span', {
+            cls: ['suggestion-flair', ...(isHidden ? ['hidden'] : [])],
+        });
 
         setIcon(flairContainer, icon, 13);
-        flairContainer.ariaLabel = isHidden ? 'Click to Show' : 'Click to Hide';
-        flairContainer.setAttr('data-command-id', match.id);
+        flairContainer.ariaLabel = isHidden ? 'Click to Unhide' : 'Click to Hide';
+        flairContainer.setAttr('data-id', match.id);
 
         flairContainer.onClickEvent((event) => {
             event.preventDefault();
@@ -319,24 +352,10 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
             const hideEl = event.target as HTMLElement;
 
-            this.currentAdapter.toggleHideId(hideEl.getAttr('data-command-id'));
+            this.currentAdapter.toggleHideId(hideEl.getAttr('data-id'));
         });
 
         this.currentAdapter.renderSuggestion(match, el);
-
-        if (this.currentAdapter.hiddenIds.includes(match.id)) {
-            // I have no idea why, but when I append the element to my hidden elements div
-            // it is automatically removed from the normal suggestions. It's what we want,
-            // but I'm just not sure why it's happening.
-            this.hiddenItemsEl.appendChild(el);
-            el.onClickEvent((event) => {
-                this.close();
-                this.onChooseSuggestion(match, event);
-            });
-            this.hiddenItemsHeaderEl.innerText = `hidden items (${this.hiddenItemsEl.childElementCount})`;
-        }
-
-        this.hiddenItemsEl.toggleClass('empty', this.hiddenItemsEl.childElementCount === 0);
     }
 
     async onChooseSuggestion(item: Match, event: MouseEvent | KeyboardEvent) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,9 @@ export interface BetterCommandPalettePluginSettings {
     hotkeyStyle: HotkeyStyleType;
     createNewFileMod: Modifier,
     createNewPaneMod: Modifier,
+    hiddenCommands: string[],
+    hiddenFiles: string[],
+    hiddenTags: string[],
 }
 
 export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
@@ -29,6 +32,9 @@ export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
     hotkeyStyle: 'auto',
     createNewFileMod: 'Mod',
     createNewPaneMod: 'Shift',
+    hiddenCommands: [],
+    hiddenFiles: [],
+    hiddenTags: [],
 };
 
 export class BetterCommandPaletteSettingTab extends PluginSettingTab {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,7 +4,42 @@
         margin: 5px;
     }
 
+    .hidden-items-header {
+        margin: 0px;
+        margin-left: 34px;
+        margin-top: 10px;
+        font-size: 15px;
+        color: var(--text-faint);
+
+        &:hover {
+            color: var(--text-muted);
+            cursor: pointer;
+        }
+    }
+
+    .prompt-results, .hidden-items {
+        flex: 1 1 400px;
+    }
+
+    .hidden-items {
+        overflow-y: auto;
+        background-color: var(--background-primary-alt);
+        margin-bottom: 5px;
+
+        &.collapsed, &.empty {
+            display: none;
+        }
+
+        .suggestion-item:hover {
+            background: var(--background-secondary)
+        }
+    }
+
     .suggestion-item {
+        .suggestion-flair {
+            color: var(--text-faint);
+        }
+
         .recent-text {
             color: var(--text-faint);
             margin-left: 10px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -18,12 +18,16 @@
     }
 
     .suggestion-item {
-        .suggestion-flair {
-            color: var(--text-faint);
+        &.hidden {
+            color: var(--text-accent);
 
-            &.hidden {
+            .suggestion-flair {
                 transform: rotate(45deg);
             }
+        }
+
+        .suggestion-flair {
+            color: var(--text-faint);
         }
 
         .recent-text {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,7 +6,7 @@
 
     .hidden-items-header {
         margin: 0px;
-        margin-left: 34px;
+        margin-left: 13px;
         margin-top: 10px;
         font-size: 15px;
         color: var(--text-faint);
@@ -17,27 +17,13 @@
         }
     }
 
-    .prompt-results, .hidden-items {
-        flex: 1 1 400px;
-    }
-
-    .hidden-items {
-        overflow-y: auto;
-        background-color: var(--background-primary-alt);
-        margin-bottom: 5px;
-
-        &.collapsed, &.empty {
-            display: none;
-        }
-
-        .suggestion-item:hover {
-            background: var(--background-secondary)
-        }
-    }
-
     .suggestion-item {
         .suggestion-flair {
             color: var(--text-faint);
+
+            &.hidden {
+                transform: rotate(45deg);
+            }
         }
 
         .recent-text {

--- a/src/utils/suggest-modal-adapter.ts
+++ b/src/utils/suggest-modal-adapter.ts
@@ -25,6 +25,10 @@ export default abstract class SuggestModalAdapter {
 
     allItems: Match[];
 
+    hiddenIds: string[];
+
+    hiddenIdsSettingsKey: 'hiddenCommands' | 'hiddenFiles' | 'hiddenTags';
+
     abstract titleText: string;
 
     abstract emptyStateText: string;
@@ -46,6 +50,7 @@ export default abstract class SuggestModalAdapter {
         this.allItems = [];
         this.pinnedItems = [];
         this.initialized = false;
+        this.hiddenIds = [];
     }
 
     getTitleText(): string {
@@ -109,5 +114,20 @@ export default abstract class SuggestModalAdapter {
         });
 
         return allItems.valuesByLastAdd();
+    }
+
+    async toggleHideId(id: string) {
+        if (this.hiddenIds.includes(id)) {
+            this.hiddenIds = this.hiddenIds.filter((idToCheck) => id !== idToCheck);
+        } else {
+            this.hiddenIds.push(id);
+        }
+
+        this.plugin.settings[this.hiddenIdsSettingsKey] = this.hiddenIds;
+
+        await this.plugin.saveSettings();
+        await this.plugin.loadSettings();
+
+        this.palette.updateSuggestions();
     }
 }

--- a/test/e2e/test-utils.ts
+++ b/test/e2e/test-utils.ts
@@ -210,8 +210,8 @@ export class TestCase {
         return this.runCommandWithRetries(this.pressKeyInternal(key, options));
     }
 
-    async assertElCount(selector: string, count: number) {
-        return this.runCommandWithRetries(this.assertEqualInternal(selector, count));
+    async assertElCount(selector: string, count: number, options: Object = {}) {
+        return this.runCommandWithRetries(this.assertEqualInternal(selector, count, options));
     }
 
     async assertExists(val: any) {

--- a/test/e2e/tests/test-command-palette.ts
+++ b/test/e2e/tests/test-command-palette.ts
@@ -50,4 +50,47 @@ testCase.addTest('Command hotkeys', async () => {
     await testCase.pressKey('Esc');
 });
 
+testCase.addTest('Empty Hidden Command Header', async () => {
+    await testCase.pressKey('P', { metaKey: true });
+    await testCase.assertElCount('.hidden-items-header', 1, { text: '' });
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Hide Command', async () => {
+    await testCase.pressKey('P', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'Tag Search');
+    await testCase.clickEl('.suggestion-flair');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: 'Show hidden items (1)' });
+    await testCase.assertElCount('.suggestion-item', 0);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Show/Hide Hidden Command', async () => {
+    await testCase.pressKey('P', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'Tag Search');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: 'Show hidden items (1)' });
+    await testCase.assertElCount('.suggestion-item', 0);
+
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.findEl('.suggestion-item.hidden', { text: 'Tag Search' });
+    await testCase.findEl('.hidden-items-header', { text: 'Hide hidden items (1)' });
+
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.assertElCount('.suggestion-item', 0);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Unhide Command', async () => {
+    await testCase.pressKey('P', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'Tag Search');
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.clickEl('.suggestion-flair');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: '' });
+    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.pressKey('Esc');
+});
+
 export default testCase;

--- a/test/e2e/tests/test-file-palette.ts
+++ b/test/e2e/tests/test-file-palette.ts
@@ -212,4 +212,47 @@ testCase.addTest('Switch new pane and file creation modifiers back to default', 
     await testCase.pressKey('Esc');
 });
 
+testCase.addTest('Empty Hidden File Header', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.assertElCount('.hidden-items-header', 1, { text: '' });
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Hide File', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'e2e-unresolved-link');
+    await testCase.clickEl('.suggestion-flair');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: 'Show hidden items (1)' });
+    await testCase.assertElCount('.suggestion-item', 0);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Show/Hide Hidden File', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'e2e-unresolved-link');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: 'Show hidden items (1)' });
+    await testCase.assertElCount('.suggestion-item', 0);
+
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.findEl('.suggestion-item.hidden', { text: 'e2e-unresolved-link' });
+    await testCase.findEl('.hidden-items-header', { text: 'Hide hidden items (1)' });
+
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.assertElCount('.suggestion-item', 0);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Unhide File', async () => {
+    await testCase.pressKey('O', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'e2e-unresolved-link');
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.clickEl('.suggestion-flair');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: '' });
+    await testCase.assertElCount('.suggestion-item', 1);
+    await testCase.pressKey('Esc');
+});
+
 export default testCase;

--- a/test/e2e/tests/test-tag-palette.ts
+++ b/test/e2e/tests/test-tag-palette.ts
@@ -24,6 +24,15 @@ testCase.addTest('Finds frontmatter tags', async () => {
     await testCase.pressKey('Esc');
 });
 
+testCase.addTest('Finds nested tags', async () => {
+    await testCase.pressKey('T', { metaKey: true });
+
+    await testCase.typeInEl('.prompt-input', 'e2e-nested-tag');
+    await testCase.assertElCount('.suggestion-item', 1);
+
+    await testCase.pressKey('Esc');
+});
+
 testCase.addTest('Tag selection opens file search', async () => {
     await testCase.pressKey('T', { metaKey: true });
     await testCase.typeInEl('.prompt-input', 'e2e-tag');
@@ -32,6 +41,49 @@ testCase.addTest('Tag selection opens file search', async () => {
     await testCase.assertElCount('.better-command-palette', 1);
     await testCase.findEl('.better-command-palette-title', { text: 'Files' });
     await testCase.assertElCount('.suggestion-item', 2);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Empty Hidden Tag Header', async () => {
+    await testCase.pressKey('T', { metaKey: true });
+    await testCase.assertElCount('.hidden-items-header', 1, { text: '' });
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Hide Tag', async () => {
+    await testCase.pressKey('T', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'e2e-tag/e2e-nested-tag');
+    await testCase.clickEl('.suggestion-flair');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: 'Show hidden items (1)' });
+    await testCase.assertElCount('.suggestion-item', 0);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Show/Hide Hidden Tag', async () => {
+    await testCase.pressKey('T', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'e2e-tag/e2e-nested-tag');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: 'Show hidden items (1)' });
+    await testCase.assertElCount('.suggestion-item', 0);
+
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.findEl('.suggestion-item.hidden', { text: 'e2e-tag/e2e-nested-tag' });
+    await testCase.findEl('.hidden-items-header', { text: 'Hide hidden items (1)' });
+
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.assertElCount('.suggestion-item', 0);
+    await testCase.pressKey('Esc');
+});
+
+testCase.addTest('Unhide Tag', async () => {
+    await testCase.pressKey('T', { metaKey: true });
+    await testCase.typeInEl('.prompt-input', 'e2e-tag/e2e-nested-tag');
+    await testCase.clickEl('.hidden-items-header');
+    await testCase.clickEl('.suggestion-flair');
+
+    await testCase.assertElCount('.hidden-items-header', 1, { text: '' });
+    await testCase.assertElCount('.suggestion-item', 1);
     await testCase.pressKey('Esc');
 });
 


### PR DESCRIPTION
* Adds the ability to hide items in the standard palette modal
* Updates each adapter class to hide relevant items specified in the settings
* Adds tests for new hiding functionality
* Adds test for a nested tag in tag palette