### PR TITLE
Add `Escape` to list of Special Keys

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -30,6 +30,7 @@ export const SPECIAL_KEYS: Record<string, string> = {
     ARROWDOWN: '↓',
     BACKSPACE: '⌫',
     ESC: 'Esc',
+    ESCAPE: 'Esc',
 };
 
 export const MACRO_COMMAND_ID_PREFIX = 'obsidian-better-command-palette-macro-';


### PR DESCRIPTION
so that this looks nicer 🙂 
<img width="1043" alt="Pasted image  2022-04-21 12 20 28" src="https://user-images.githubusercontent.com/73286100/164434841-25b9a89d-0f08-4cf8-90fb-1b1e8cfdb2d0.png">
