### PR TITLE
Implement "Meh Key", analog to the Hyper Key

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,6 +2,7 @@ import {
     App, Command, Modifier, PluginSettingTab, setIcon, Setting,
 } from 'obsidian';
 import BetterCommandPalettePlugin from 'src/main';
+import { MAC_MODIFIER_ICONS } from './utils/constants';
 import { HotkeyStyleType, MacroCommandInterface, UnsafeAppInterface } from './types/types';
 import { SettingsCommandSuggestModal } from './utils';
 
@@ -80,7 +81,7 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Caps Lock Hyper Key Hotkey Override')
-            .setDesc('For those users who have use a "Hyper Key", enabling this maps the icons "⌥ ^ ⌘ ⇧" to the caps lock icon "⇪" ')
+            .setDesc(`For those users who have use a "Hyper Key", enabling this maps the icons "⌥ ^ ⌘ ⇧" to the caps lock icon "${MAC_MODIFIER_ICONS.Hyper}"`)
             .addToggle((t) => t.setValue(settings.hyperKeyOverride).onChange(async (val) => {
                 settings.hyperKeyOverride = val;
                 await this.plugin.saveSettings();
@@ -88,7 +89,7 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Meh Key Hotkey Override')
-            .setDesc('For those users who have use a "Meh Key", enabling this maps the icons "⌥ ^ ⇧" to the Meh icon "☉" ')
+            .setDesc(`For those users who have use a "Hyper Key", enabling this maps the icons "⌥ ^ ⇧" to the Meh icon "${MAC_MODIFIER_ICONS.Meh}"`)
             .addToggle((t) => t.setValue(settings.mehKeyOverride).onChange(async (val) => {
                 settings.mehKeyOverride = val;
                 await this.plugin.saveSettings();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export interface BetterCommandPalettePluginSettings {
     suggestionLimit: number,
     recentAbovePinned: boolean,
     hyperKeyOverride: boolean,
+    mehKeyOverride: boolean,
     macros: MacroCommandInterface[],
     hotkeyStyle: HotkeyStyleType;
     createNewFileMod: Modifier,
@@ -28,6 +29,7 @@ export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
     suggestionLimit: 50,
     recentAbovePinned: false,
     hyperKeyOverride: false,
+    mehKeyOverride: false,
     macros: [],
     hotkeyStyle: 'auto',
     createNewFileMod: 'Mod',
@@ -81,6 +83,14 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
             .setDesc('For those users who have use a "Hyper Key", enabling this maps the icons "⌥ ^ ⌘ ⇧" to the caps lock icon "⇪" ')
             .addToggle((t) => t.setValue(settings.hyperKeyOverride).onChange(async (val) => {
                 settings.hyperKeyOverride = val;
+                await this.plugin.saveSettings();
+            }));
+
+        new Setting(containerEl)
+            .setName('Meh Key Hotkey Override')
+            .setDesc('For those users who have use a "Meh Key", enabling this maps the icons "⌥ ^ ⇧" to the Meh icon "☉" ')
+            .addToggle((t) => t.setValue(settings.mehKeyOverride).onChange(async (val) => {
+                settings.mehKeyOverride = val;
                 await this.plugin.saveSettings();
             }));
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,6 +2,7 @@ export const QUERY_OR = '||';
 export const QUERY_TAG = '@';
 
 export const HYPER_KEY_MODIFIERS_SET = new Set(['Alt', 'Ctrl', 'Mod', 'Shift']);
+export const MEH_KEY_MODIFIERS_SET = new Set(['Alt', 'Ctrl', 'Shift']);
 
 export const BASIC_MODIFIER_ICONS = {
     Mod: 'Ctrl +',
@@ -10,6 +11,7 @@ export const BASIC_MODIFIER_ICONS = {
     Alt: 'Alt +',
     Shift: 'Shift +',
     Hyper: 'Caps +',
+    Meh: 'Meh +',
 };
 
 export const MAC_MODIFIER_ICONS = {
@@ -19,6 +21,8 @@ export const MAC_MODIFIER_ICONS = {
     Alt: '⌥',
     Shift: '⇧',
     Hyper: '⇪',
+    Meh: '☉',
+    Esc: '⎋',
 };
 
 export const SPECIAL_KEYS: Record<string, string> = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,6 +22,13 @@ function isHyperKey(modifiers: Modifier[]) : boolean {
 
     return modifiers.every((m) => HYPER_KEY_MODIFIERS_SET.has(m));
 }
+function isMehKey(modifiers: Modifier[]) : boolean {
+    if (modifiers.length !== 3) {
+        return false;
+    }
+
+    return modifiers.every((m) => HYPER_KEY_MODIFIERS_SET.has(m));
+}
 
 /**
  * A utility that generates the text of a Hotkey for UIs
@@ -44,6 +51,14 @@ export function generateHotKeyText(
 
     if (settings.hyperKeyOverride && isHyperKey(hotkey.modifiers)) {
         hotKeyStrings.push(modifierIcons.Hyper);
+    } else {
+        hotkey.modifiers.forEach((mod: Modifier) => {
+            hotKeyStrings.push(modifierIcons[mod]);
+        });
+    }
+
+    if (settings.mehKeyOverride && isMehKey(hotkey.modifiers)) {
+        hotKeyStrings.push(modifierIcons.Meh);
     } else {
         hotkey.modifiers.forEach((mod: Modifier) => {
             hotKeyStrings.push(modifierIcons[mod]);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -51,13 +51,7 @@ export function generateHotKeyText(
 
     if (settings.hyperKeyOverride && isHyperKey(hotkey.modifiers)) {
         hotKeyStrings.push(modifierIcons.Hyper);
-    } else {
-        hotkey.modifiers.forEach((mod: Modifier) => {
-            hotKeyStrings.push(modifierIcons[mod]);
-        });
-    }
-
-    if (settings.mehKeyOverride && isMehKey(hotkey.modifiers)) {
+    } else if (settings.mehKeyOverride && isMehKey(hotkey.modifiers)) {
         hotKeyStrings.push(modifierIcons.Meh);
     } else {
         hotkey.modifiers.forEach((mod: Modifier) => {


### PR DESCRIPTION
> A meh key, which is a less-hyper version of the Hyper key (sends Alt+Ctrl+Shift, without Cmd/Ctrl).

https://ergodox-ez.com/pages/our-firmware

basically replicates the the setting and implementation of the hyper key, only for the meh key. (Since I do not know of an icon for the Meh key, I simply chose a "neutral" one.)