### PR TITLE
Fix separator between command collection and command names

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -66,6 +66,10 @@
             }
         }
     }
+
+    .suggestion-prefix:after {
+        content: ": ";
+    }
 }
 
 /* Settings Styles */


### PR DESCRIPTION
Fix for #68. This is just implementing changes suggested by @brimwats in this comment: https://github.com/AlexBieg/obsidian-better-command-palette/issues/68#issuecomment-1229373456.