### PR TITLE
Css fixups

### DIFF
--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -84,10 +84,12 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
             const prefix = split.shift();
             text = split.join(this.COMMAND_PLUGIN_NAME_SEPARATOR);
 
-            el.createEl('span', {
-                cls: 'suggestion-prefix',
-                text: prefix,
-            });
+            if (this.plugin.settings.showPluginName) {
+                el.createEl('span', {
+                    cls: 'suggestion-prefix',
+                    text: prefix,
+                });
+            }
         }
 
         el.createEl('span', {

--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -55,7 +55,7 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
         ];
     }
 
-    renderSuggestion(match: Match, el: HTMLElement): void {
+    renderSuggestion(match: Match, content: HTMLElement, aux: HTMLElement): void {
         const command = this.app.commands.findCommand(match.id);
         const customHotkeys = this.app.hotkeyManager.getHotkeys(command.id);
         const defaultHotkeys = this.app.hotkeyManager.getDefaultHotkeys(command.id);
@@ -67,13 +67,14 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
         const hotkeys = customHotkeys || defaultHotkeys || [];
 
         if (this.getPinnedItems().find((i) => i.id === match.id)) {
-            const flairContainer = el.querySelector('.suggestion-flair') as HTMLElement;
+            const flairContainer = aux.querySelector('.suggestion-flair') as HTMLElement;
             setIcon(flairContainer, 'filled-pin', 13);
             flairContainer.ariaLabel = 'Pinned';
             flairContainer.onClickEvent(() => {});
         }
 
         let { text } = match;
+        let prefix = '';
 
         // Has a plugin name prefix
         if (text.includes(this.COMMAND_PLUGIN_NAME_SEPARATOR)) {
@@ -81,24 +82,24 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
             // Seems like this is how the acutal command palette does it though
             const split = text.split(this.COMMAND_PLUGIN_NAME_SEPARATOR);
             // Get first element
-            const prefix = split.shift();
+            prefix = split.shift();
             text = split.join(this.COMMAND_PLUGIN_NAME_SEPARATOR);
-
-            if (this.plugin.settings.showPluginName) {
-                el.createEl('span', {
-                    cls: 'suggestion-prefix',
-                    text: prefix,
-                });
-            }
         }
 
-        el.createEl('span', {
-            cls: 'suggestion-content',
+        content.createEl('span', {
+            cls: 'suggestion-title',
             text,
         });
 
+        if (prefix && this.plugin.settings.showPluginName) {
+            content.createEl('span', {
+                cls: 'suggestion-note',
+                text: prefix,
+            });
+        }
+
         hotkeys.forEach((hotkey) => {
-            el.createEl('kbd', {
+            aux.createEl('kbd', {
                 cls: 'suggestion-hotkey',
                 text: generateHotKeyText(hotkey, this.plugin.settings),
             });

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -82,9 +82,9 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         return newQuery;
     }
 
-    renderSuggestion(match: Match, el: HTMLElement): void {
-        const suggestionEl = el.createEl('div', {
-            cls: 'suggestion-content',
+    renderSuggestion(match: Match, content: HTMLElement): void {
+        const suggestionEl = content.createEl('div', {
+            cls: 'suggestion-title',
             text: match.text,
         });
 
@@ -94,7 +94,7 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
 
         if (match.id.includes(':')) {
             // Set Icon will destroy the first element in a node. So we need to add one back
-            suggestionEl.createEl('div', {
+            suggestionEl.createEl('span', {
                 cls: 'suggestion-name',
                 text: match.text,
             }).ariaLabel = 'Alias';
@@ -102,14 +102,14 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
             setIcon(suggestionEl, 'right-arrow-with-tail');
 
             const [, path] = match.id.split(':');
-            suggestionEl.createEl('div', {
-                cls: 'suggestion-description',
+            suggestionEl.createEl('span', {
+                cls: 'suggestion-note',
                 text: path,
             });
         }
 
-        el.createEl('div', {
-            cls: 'suggestion-sub-content',
+        content.createEl('div', {
+            cls: 'suggestion-note',
             text: `${match.tags.join(' ')}`,
         });
     }

--- a/src/palette-modal-adapters/tag-adapter.ts
+++ b/src/palette-modal-adapters/tag-adapter.ts
@@ -45,16 +45,16 @@ export default class BetterCommandPaletteTagAdapter extends SuggestModalAdapter 
         return query.replace(this.tagSearchPrefix, '');
     }
 
-    renderSuggestion(match: Match, el: HTMLElement): void {
-        el.createEl('span', {
+    renderSuggestion(match: Match, content: HTMLElement, aux: HTMLElement): void {
+        content.createEl('span', {
             cls: 'suggestion-content',
             text: match.text,
         });
 
         const count = parseInt(match.tags[0], 10);
 
-        el.createEl('div', {
-            cls: 'suggestion-sub-content',
+        aux.createEl('span', {
+            cls: 'suggestion-flair',
             text: `Found in ${count} file${count === 1 ? '' : 's'}`,
         });
     }

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -327,17 +327,21 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
     }
 
     renderSuggestion(match: Match, el: HTMLElement) {
+        el.addClass('mod-complex');
+
         const isHidden = this.currentAdapter.hiddenIds.includes(match.id);
 
         if (isHidden) {
             el.addClass('hidden');
         }
 
-        renderPrevItems(match, el, this.currentAdapter.getPrevItems());
-
         const icon = 'cross';
 
-        const flairContainer = el.createEl('span', 'suggestion-flair');
+        const suggestionContent = el.createEl('span', 'suggestion-content');
+        const suggestionAux = el.createEl('span', 'suggestion-aux');
+
+        const flairContainer = suggestionAux.createEl('span', 'suggestion-flair');
+        renderPrevItems(match, suggestionContent, this.currentAdapter.getPrevItems());
 
         setIcon(flairContainer, icon, 13);
         flairContainer.ariaLabel = isHidden ? 'Click to Unhide' : 'Click to Hide';
@@ -352,7 +356,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
             this.currentAdapter.toggleHideId(hideEl.getAttr('data-id'));
         });
 
-        this.currentAdapter.renderSuggestion(match, el);
+        this.currentAdapter.renderSuggestion(match, suggestionContent, suggestionAux);
     }
 
     async onChooseSuggestion(item: Match, event: MouseEvent | KeyboardEvent) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ import { SettingsCommandSuggestModal } from './utils';
 
 export interface BetterCommandPalettePluginSettings {
     closeWithBackspace: boolean,
+    showPluginName: boolean,
     fileSearchPrefix: string,
     tagSearchPrefix: string,
     suggestionLimit: number,
@@ -23,6 +24,7 @@ export interface BetterCommandPalettePluginSettings {
 
 export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
     closeWithBackspace: true,
+    showPluginName: true,
     fileSearchPrefix: '/',
     tagSearchPrefix: '#',
     suggestionLimit: 50,
@@ -65,6 +67,14 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
             .setDesc('Close the palette when there is no text and backspace is pressed')
             .addToggle((t) => t.setValue(settings.closeWithBackspace).onChange(async (val) => {
                 settings.closeWithBackspace = val;
+                await this.plugin.saveSettings();
+            }));
+
+        new Setting(containerEl)
+            .setName('Show Plugin Name')
+            .setDesc('Close show the plugin name in the command palette')
+            .addToggle((t) => t.setValue(settings.showPluginName).onChange(async (val) => {
+                settings.showPluginName = val;
                 await this.plugin.saveSettings();
             }));
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,6 +28,14 @@
 
         .suggestion-flair {
             color: var(--text-faint);
+            margin-right: 10px;
+        }
+
+        .suggestion-hotkey {
+            white-space: nowrap;
+            margin-left: 10px;
+            float: right;
+            padding: 0px 10px;
         }
 
         .recent-text {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -34,34 +34,27 @@
         .suggestion-hotkey {
             white-space: nowrap;
             margin-left: 10px;
-            float: right;
             padding: 0px 10px;
         }
 
-        .recent-text {
-            color: var(--text-faint);
-            margin-left: 10px;
-            float: right;
-        }
-
         .suggestion-content {
-            display: inline-flex;
-            align-items: center;
-
             svg {
                 margin: 0px 5px;
                 color: var(--text-muted);
             }
         }
 
-        .suggestion-description {
-            display: inline;
-            color: var(--text-muted);
+        .suggestion-aux {
+            flex-direction: row-reverse;
         }
 
+        .suggestion-title {
+            display: flex;
+            align-items: center;
+        }
 
-        .suggestion-sub-content {
-            color: var(--text-faint);
+        .suggestion-note {
+            flex: 1;
         }
 
         .unresolved {
@@ -73,10 +66,6 @@
                 margin-left: 10px;
             }
         }
-    }
-
-    .suggestion-prefix:after {
-        content: ": ";
     }
 }
 

--- a/src/utils/suggest-modal-adapter.ts
+++ b/src/utils/suggest-modal-adapter.ts
@@ -33,7 +33,7 @@ export default abstract class SuggestModalAdapter {
 
     abstract emptyStateText: string;
 
-    abstract renderSuggestion(match: Match, el: HTMLElement): void;
+    abstract renderSuggestion(match: Match, content: HTMLElement, aux: HTMLElement): void;
     abstract onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent): void;
 
     constructor(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -60,7 +60,7 @@ export function renderPrevItems(match: Match, el: HTMLElement, prevItems: Ordere
     if (prevItems.has(match)) {
         el.addClass('recent');
         el.createEl('span', {
-            cls: 'recent-text',
+            cls: 'suggestion-note',
             text: '(recently used)',
         });
     }


### PR DESCRIPTION
- Fixes a number of styling issues from obsidian updates
- Adds setting to hide the plugin name in the command palette
- Updates the dom to match the newer dom structure of suggest modals