### PR TITLE
Turned on "strict" in tsconfig 

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ export default {
         scss({
             output: `${outputLocation}/styles.css`,
         }),
-        // eslint(),
+        eslint(),
         copy({
             targets: [
                 ...(!isLocal

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,15 +9,15 @@ import { MACRO_COMMAND_ID_PREFIX } from './utils/constants';
 import './styles.scss';
 
 export default class BetterCommandPalettePlugin extends Plugin {
-    app: UnsafeAppInterface;
+    declare app: UnsafeAppInterface;
 
-    settings: BetterCommandPalettePluginSettings;
+    settings!: BetterCommandPalettePluginSettings;
 
-    prevCommands: OrderedSet<Match>;
+    prevCommands!: OrderedSet<Match>;
 
-    prevTags: OrderedSet<Match>;
+    prevTags!: OrderedSet<Match>;
 
-    suggestionsWorker: Worker;
+    suggestionsWorker!: Worker;
 
     async onload() {
         // eslint-disable-next-line no-console

--- a/src/palette-modal-adapters/command-adapter.ts
+++ b/src/palette-modal-adapters/command-adapter.ts
@@ -6,18 +6,18 @@ import { Match, UnsafeAppInterface } from 'src/types/types';
 import { ActionType } from 'src/utils/constants';
 
 export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdapter {
-    titleText: string;
+    titleText!: string;
 
-    emptyStateText: string;
+    emptyStateText!: string;
 
     COMMAND_PLUGIN_NAME_SEPARATOR = ': ';
 
     // Unsafe Interfaces
-    app: UnsafeAppInterface;
+    declare app: UnsafeAppInterface;
 
-    allItems: Match[];
+    allItems!: Match[];
 
-    pinnedItems: Match[];
+    pinnedItems!: Match[];
 
     initialize() {
         super.initialize();
@@ -90,7 +90,7 @@ export default class BetterCommandPaletteCommandAdapter extends SuggestModalAdap
             // Seems like this is how the acutal command palette does it though
             const split = text.split(this.COMMAND_PLUGIN_NAME_SEPARATOR);
             // Get first element
-            prefix = split.shift();
+            prefix = split.shift()!;
             text = split.join(this.COMMAND_PLUGIN_NAME_SEPARATOR);
         }
 

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -26,7 +26,7 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
 
     fileSearchPrefix!: string;
 
-    initialize () {
+    initialize() {
         super.initialize();
 
         this.titleText = 'Better Command Palette: Files';
@@ -71,14 +71,14 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         });
     }
 
-    mount (): void {
+    mount(): void {
         this.keymapHandlers = [
             this.palette.scope.register(['Mod'], this.plugin.settings.commandSearchHotkey, () => this.palette.changeActionType(ActionType.Commands)),
             this.palette.scope.register(['Mod'], this.plugin.settings.tagSearchHotkey, () => this.palette.changeActionType(ActionType.Tags)),
         ];
     }
 
-    getInstructions (): Instruction[] {
+    getInstructions(): Instruction[] {
         const { openInNewTabMod, createNewFileMod } = this.plugin.settings;
         return [
             { command: generateHotKeyText({ modifiers: [], key: 'ENTER' }, this.plugin.settings), purpose: 'Open file' },
@@ -89,27 +89,27 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         ];
     }
 
-    cleanQuery (query: string): string {
+    cleanQuery(query: string): string {
         const newQuery = query.replace(this.fileSearchPrefix, '');
         return newQuery;
     }
 
-    renderSuggestion (match: Match, content: HTMLElement): void {
+    renderSuggestion(match: Match, content: HTMLElement): void {
         let noteName = match.text;
 
         // Build the displayed note name without its full path if required in settings
         if (this.plugin.settings.displayOnlyNotesNames) {
-            noteName = match.text.split("/").pop();
+            noteName = match.text.split('/').pop()!;
         }
 
         // Build the displayed note name without its Markdown extension if required in settings
-        if (this.plugin.settings.hideMdExtension && noteName.endsWith(".md")) {
+        if (this.plugin.settings.hideMdExtension && noteName.endsWith('.md')) {
             noteName = noteName.slice(0, -3);
         }
 
         const suggestionEl = content.createEl('div', {
             cls: 'suggestion-title',
-            text: noteName
+            text: noteName,
         });
 
         if (this.unresolvedItems.has(match)) {
@@ -138,7 +138,7 @@ export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter
         });
     }
 
-    async onChooseSuggestion (match: Match, event: MouseEvent | KeyboardEvent) {
+    async onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent) {
         let path = match && match.id;
 
         // No match means we are trying to create new file

--- a/src/palette-modal-adapters/file-adapter.ts
+++ b/src/palette-modal-adapters/file-adapter.ts
@@ -13,18 +13,18 @@ import { Match, UnsafeAppInterface } from 'src/types/types';
 import { ActionType } from 'src/utils/constants';
 
 export default class BetterCommandPaletteFileAdapter extends SuggestModalAdapter {
-    titleText: string;
+    titleText!: string;
 
-    emptyStateText: string;
+    emptyStateText!: string;
 
     // Unsafe interface
-    app: UnsafeAppInterface;
+    declare app: UnsafeAppInterface;
 
-    allItems: Match[];
+    allItems!: Match[];
 
-    unresolvedItems: OrderedSet<Match>;
+    unresolvedItems!: OrderedSet<Match>;
 
-    fileSearchPrefix: string;
+    fileSearchPrefix!: string;
 
     initialize () {
         super.initialize();

--- a/src/palette-modal-adapters/tag-adapter.ts
+++ b/src/palette-modal-adapters/tag-adapter.ts
@@ -8,16 +8,16 @@ import { ActionType, QUERY_TAG } from 'src/utils/constants';
 import { Match, UnsafeAppInterface } from '../types/types';
 
 export default class BetterCommandPaletteTagAdapter extends SuggestModalAdapter {
-    titleText: string;
+    titleText!: string;
 
-    emptyStateText: string;
+    emptyStateText!: string;
 
     // Unsafe interface
-    app: UnsafeAppInterface;
+    declare app: UnsafeAppInterface;
 
-    allItems: Match[];
+    allItems!: Match[];
 
-    tagSearchPrefix: string;
+    tagSearchPrefix!: string;
 
     initialize(): void {
         super.initialize();

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -14,13 +14,13 @@ import { ActionType } from './utils/constants';
 
 class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSuggestModalInterface {
     // Unsafe interface
-    chooser: UnsafeSuggestModalInterface['chooser'];
+    declare chooser: UnsafeSuggestModalInterface['chooser'];
 
-    updateSuggestions: UnsafeSuggestModalInterface['updateSuggestions'];
+    declare updateSuggestions: UnsafeSuggestModalInterface['updateSuggestions'];
 
     plugin: BetterCommandPalettePlugin;
 
-    actionType: ActionType;
+    actionType!: ActionType;
 
     fileSearchPrefix: string;
 
@@ -28,9 +28,9 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
     suggestionsWorker: Worker;
 
-    currentSuggestions: Match[];
+    currentSuggestions!: Match[];
 
-    lastQuery: string;
+    lastQuery!: string;
 
     modalTitleEl: HTMLElement;
 
@@ -46,7 +46,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
     tagAdapter: BetterCommandPaletteTagAdapter;
 
-    currentAdapter: SuggestModalAdapter;
+    currentAdapter!: SuggestModalAdapter;
 
     suggestionLimit: number;
 
@@ -388,7 +388,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
             const hideEl = event.target as HTMLElement;
 
-            this.currentAdapter.toggleHideId(hideEl.getAttr('data-id'));
+            this.currentAdapter.toggleHideId(hideEl.getAttr('data-id')!);
         });
 
         this.currentAdapter.renderSuggestion(match, suggestionContent, suggestionAux);

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -50,7 +50,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
     suggestionLimit: number;
 
-    constructor (
+    constructor(
         app: App,
         prevCommands: OrderedSet<Match>,
         prevTags: OrderedSet<Match>,
@@ -119,7 +119,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.setScopes(plugin);
     }
 
-    close (evt?: KeyboardEvent) {
+    close(evt?: KeyboardEvent) {
         super.close();
 
         if (evt) {
@@ -127,7 +127,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         }
     }
 
-    setScopes (plugin: BetterCommandPalettePlugin) {
+    setScopes(plugin: BetterCommandPalettePlugin) {
         const closeModal = (event: KeyboardEvent) => {
             // Have to cast this to access `value`
             const el = event.target as HTMLInputElement;
@@ -163,10 +163,13 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
 
         this.scope.register([openInNewTabMod], 'Enter', (event: KeyboardEvent) => {
             if (this.actionType === ActionType.Files && this.currentSuggestions.length) {
-                const promptResults = document.querySelector(".better-command-palette .prompt-results");
-                const selected = document.querySelector(".better-command-palette .is-selected");
+                const promptResults = document.querySelector('.better-command-palette .prompt-results')!;
+                const selected = document.querySelector('.better-command-palette .is-selected')!;
                 const selectedIndex = Array.from(promptResults.children).indexOf(selected);
-                this.currentAdapter.onChooseSuggestion(this.currentSuggestions[selectedIndex], event);
+                this.currentAdapter.onChooseSuggestion(
+                    this.currentSuggestions[selectedIndex],
+                    event,
+                );
                 this.close(event);
             }
         });
@@ -179,7 +182,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.updateSuggestions();
     };
 
-    onOpen () {
+    onOpen() {
         super.onOpen();
 
         // Add the initial value to the input
@@ -191,13 +194,12 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         }
     }
 
-    changeActionType (actionType: ActionType) {
+    changeActionType(actionType: ActionType) {
         let prefix = '';
         if (actionType === ActionType.Files) {
             prefix = this.plugin.settings.fileSearchPrefix;
         } else if (actionType === ActionType.Tags) {
             prefix = this.plugin.settings.tagSearchPrefix;
-
         }
         const currentQuery: string = this.inputEl.value;
         const cleanQuery = this.currentAdapter.cleanQuery(currentQuery);
@@ -206,7 +208,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.updateSuggestions();
     }
 
-    setQuery (
+    setQuery(
         newQuery: string,
         cursorPosition: number = -1,
     ) {
@@ -219,7 +221,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.updateSuggestions();
     }
 
-    updateActionType (): boolean {
+    updateActionType(): boolean {
         const text: string = this.inputEl.value;
         let nextAdapter;
         let type;
@@ -227,15 +229,15 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         if (text.startsWith(this.fileSearchPrefix)) {
             type = ActionType.Files;
             nextAdapter = this.fileAdapter;
-            this.modalEl.setAttribute("palette-mode", "files");
+            this.modalEl.setAttribute('palette-mode', 'files');
         } else if (text.startsWith(this.tagSearchPrefix)) {
             type = ActionType.Tags;
             nextAdapter = this.tagAdapter;
-            this.modalEl.setAttribute("palette-mode", "tags");
+            this.modalEl.setAttribute('palette-mode', 'tags');
         } else {
             type = ActionType.Commands;
             nextAdapter = this.commandAdapter;
-            this.modalEl.setAttribute("palette-mode", "commands");
+            this.modalEl.setAttribute('palette-mode', 'commands');
         }
 
         if (type !== this.actionType) {
@@ -263,7 +265,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         return wasUpdated;
     }
 
-    updateTitleText () {
+    updateTitleText() {
         if (this.plugin.settings.showPluginName) {
             this.modalTitleEl.setText(this.currentAdapter.getTitleText());
         } else {
@@ -271,11 +273,11 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         }
     }
 
-    updateEmptyStateText () {
+    updateEmptyStateText() {
         this.emptyStateText = this.currentAdapter.getEmptyStateText();
     }
 
-    updateInstructions () {
+    updateInstructions() {
         Array.from(this.modalEl.getElementsByClassName('prompt-instructions'))
             .forEach((instruction) => {
                 this.modalEl.removeChild(instruction);
@@ -288,11 +290,11 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         ]);
     }
 
-    getItems (): Match[] {
+    getItems(): Match[] {
         return this.currentAdapter.getSortedItems();
     }
 
-    receivedSuggestions (msg: MessageEvent) {
+    receivedSuggestions(msg: MessageEvent) {
         const results = [];
         let hiddenCount = 0;
 
@@ -319,7 +321,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.updateSuggestions();
     }
 
-    getSuggestionsAsync (query: string) {
+    getSuggestionsAsync(query: string) {
         const items = this.getItems();
         this.suggestionsWorker.postMessage({
             query,
@@ -327,7 +329,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         });
     }
 
-    getSuggestions (query: string): Match[] {
+    getSuggestions(query: string): Match[] {
         // The action type might have changed
         this.updateActionType();
 
@@ -352,7 +354,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         return this.showHiddenItems ? this.currentSuggestions : visibleItems;
     }
 
-    updateHiddenItemCountHeader (hiddenItemCount: number) {
+    updateHiddenItemCountHeader(hiddenItemCount: number) {
         this.hiddenItemsHeaderEl.empty();
 
         if (hiddenItemCount !== 0) {
@@ -361,7 +363,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         }
     }
 
-    renderSuggestion (match: Match, el: HTMLElement) {
+    renderSuggestion(match: Match, el: HTMLElement) {
         el.addClass('mod-complex');
 
         const isHidden = this.currentAdapter.hiddenIds.includes(match.id);
@@ -376,7 +378,12 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         const suggestionAux = el.createEl('span', 'suggestion-aux');
 
         const flairContainer = suggestionAux.createEl('span', 'suggestion-flair');
-        renderPrevItems(this.plugin.settings, match, suggestionContent, this.currentAdapter.getPrevItems());
+        renderPrevItems(
+            this.plugin.settings,
+            match,
+            suggestionContent,
+            this.currentAdapter.getPrevItems(),
+        );
 
         setIcon(flairContainer, icon, 13);
         flairContainer.ariaLabel = isHidden ? 'Click to Unhide' : 'Click to Hide';
@@ -394,7 +401,7 @@ class BetterCommandPaletteModal extends SuggestModal<Match> implements UnsafeSug
         this.currentAdapter.renderSuggestion(match, suggestionContent, suggestionAux);
     }
 
-    async onChooseSuggestion (item: Match, event: MouseEvent | KeyboardEvent) {
+    async onChooseSuggestion(item: Match, event: MouseEvent | KeyboardEvent) {
         this.currentAdapter.onChooseSuggestion(item, event);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -56,7 +56,7 @@ export const DEFAULT_SETTINGS: BetterCommandPalettePluginSettings = {
 export class BetterCommandPaletteSettingTab extends PluginSettingTab {
     plugin: BetterCommandPalettePlugin;
 
-    app: UnsafeAppInterface;
+    declare app: UnsafeAppInterface;
 
     constructor (app: App, plugin: BetterCommandPalettePlugin) {
         super(app, plugin);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,18 +58,18 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
 
     declare app: UnsafeAppInterface;
 
-    constructor (app: App, plugin: BetterCommandPalettePlugin) {
+    constructor(app: App, plugin: BetterCommandPalettePlugin) {
         super(app, plugin);
         this.plugin = plugin;
     }
 
-    display (): void {
+    display(): void {
         this.containerEl.empty();
         this.displayBasicSettings();
         this.displayMacroSettings();
     }
 
-    displayBasicSettings (): void {
+    displayBasicSettings(): void {
         const { containerEl } = this;
         const { settings } = this.plugin;
 
@@ -119,20 +119,19 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName("Display only notes' names")
-            .setDesc("If enabled, only notes names will be displayed in Quick Switcher mode instead of their full path.")
+            .setDesc('If enabled, only notes names will be displayed in Quick Switcher mode instead of their full path.')
             .addToggle((t) => t.setValue(settings.displayOnlyNotesNames).onChange(async (val) => {
                 settings.displayOnlyNotesNames = val;
                 await this.plugin.saveSettings();
             }));
 
         new Setting(containerEl)
-            .setName("Hide .md extensions")
-            .setDesc("If enabled, Markdown notes will be displayed without their .md extension in Quick Switcher mode")
+            .setName('Hide .md extensions')
+            .setDesc('If enabled, Markdown notes will be displayed without their .md extension in Quick Switcher mode')
             .addToggle((t) => t.setValue(settings.hideMdExtension).onChange(async (val) => {
                 settings.hideMdExtension = val;
                 await this.plugin.saveSettings();
             }));
-
 
         new Setting(containerEl)
             .setName('Recently used text')
@@ -239,7 +238,7 @@ export class BetterCommandPaletteSettingTab extends PluginSettingTab {
                 }));
     }
 
-    displayMacroSettings (): void {
+    displayMacroSettings(): void {
         const { containerEl } = this;
         const { settings } = this.plugin;
 

--- a/src/utils/macro.ts
+++ b/src/utils/macro.ts
@@ -71,7 +71,7 @@ export default class MacroCommand implements Command, MacroCommandInterface {
         return true;
     }
 
-    checkCallback(checking: boolean): boolean | void {
+    checkCallback(checking: boolean): boolean | null {
         if (checking) {
             return this.commandIsAvailable(this.commandIds[0]);
         }

--- a/src/utils/macro.ts
+++ b/src/utils/macro.ts
@@ -71,12 +71,12 @@ export default class MacroCommand implements Command, MacroCommandInterface {
         return true;
     }
 
-    checkCallback(checking: boolean): boolean | null {
+    checkCallback(checking: boolean): boolean | void {
         if (checking) {
             return this.commandIsAvailable(this.commandIds[0]);
         }
 
         this.callAllCommands();
-        return null;
+        return undefined;
     }
 }

--- a/src/utils/settings-command-suggest-modal.ts
+++ b/src/utils/settings-command-suggest-modal.ts
@@ -3,7 +3,7 @@ import { UnsafeAppInterface } from 'src/types/types';
 import { getCommandText } from './utils';
 
 export default class CommandSuggestModal extends FuzzySuggestModal<Command> {
-    app: UnsafeAppInterface;
+    declare app: UnsafeAppInterface;
 
     callback: (item: Command) => void;
 

--- a/src/utils/suggest-modal-adapter.ts
+++ b/src/utils/suggest-modal-adapter.ts
@@ -27,7 +27,7 @@ export default abstract class SuggestModalAdapter {
 
     hiddenIds: string[];
 
-    hiddenIdsSettingsKey: 'hiddenCommands' | 'hiddenFiles' | 'hiddenTags';
+    hiddenIdsSettingsKey!: 'hiddenCommands' | 'hiddenFiles' | 'hiddenTags';
 
     keymapHandlers: KeymapEventHandler[];
 
@@ -36,7 +36,7 @@ export default abstract class SuggestModalAdapter {
     abstract emptyStateText: string;
 
     abstract renderSuggestion(match: Match, content: HTMLElement, aux: HTMLElement): void;
-    abstract onChooseSuggestion(match: Match, event: MouseEvent | KeyboardEvent): void;
+    abstract onChooseSuggestion(match: Match | null, event: MouseEvent | KeyboardEvent): void;
 
     constructor(
         app: App,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,7 +15,7 @@ import {
  * @param {Modifier[]} modifiers An array of modifiers
  * @returns {boolean} Do the modifiers make up a hyper key command
  */
-function isHyperKey (modifiers: Modifier[]): boolean {
+function isHyperKey(modifiers: Modifier[]): boolean {
     if (modifiers.length !== 4) {
         return false;
     }
@@ -28,7 +28,7 @@ function isHyperKey (modifiers: Modifier[]): boolean {
  * @param {Hotkey} hotkey The hotkey to generate text for
  * @returns {string} The hotkey text
  */
-export function generateHotKeyText (
+export function generateHotKeyText(
     hotkey: Hotkey,
     settings: BetterCommandPalettePluginSettings,
 ): string {
@@ -56,7 +56,12 @@ export function generateHotKeyText (
     return hotKeyStrings.join(' ');
 }
 
-export function renderPrevItems (settings: BetterCommandPalettePluginSettings, match: Match, el: HTMLElement, prevItems: OrderedSet<Match>) {
+export function renderPrevItems(
+    settings: BetterCommandPalettePluginSettings,
+    match: Match,
+    el: HTMLElement,
+    prevItems: OrderedSet<Match>,
+) {
     if (prevItems.has(match)) {
         el.addClass('recent');
         el.createEl('span', {
@@ -66,11 +71,11 @@ export function renderPrevItems (settings: BetterCommandPalettePluginSettings, m
     }
 }
 
-export function getCommandText (item: Command): string {
+export function getCommandText(item: Command): string {
     return item.name;
 }
 
-export async function getOrCreateFile (app: App, path: string): Promise<TFile> {
+export async function getOrCreateFile(app: App, path: string): Promise<TFile> {
     let file = app.metadataCache.getFirstLinkpathDest(path, '');
 
     if (!file) {
@@ -89,7 +94,7 @@ export async function getOrCreateFile (app: App, path: string): Promise<TFile> {
     return file;
 }
 
-export function openFileWithEventKeys (
+export function openFileWithEventKeys(
     app: App,
     settings: BetterCommandPalettePluginSettings,
     file: TFile,
@@ -102,7 +107,7 @@ export function openFileWithEventKeys (
     app.workspace.openLinkText(file.path, file.path, openInNewTab);
 }
 
-export function matchTag (tags: string[], tagQueries: string[]): boolean {
+export function matchTag(tags: string[], tagQueries: string[]): boolean {
     for (let i = 0; i < tagQueries.length; i += 1) {
         const tagSearch = tagQueries[i];
 
@@ -120,7 +125,7 @@ export function matchTag (tags: string[], tagQueries: string[]): boolean {
     return false;
 }
 
-export function createPaletteMatchesFromFilePath (
+export function createPaletteMatchesFromFilePath(
     metadataCache: UnsafeMetadataCacheInterface,
     filePath: string,
 ): PaletteMatch[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
       "ES5",
       "ES6",
       "ES7"
-    ]
+	],
+	"strict": true
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
This PR turns on "strict" in tsconfig.json and fixes the resulting type errors, mostly by adding the "!" character to assert that values are non-null and member variables are initialized before they are used, based on the assumption that the existing code is correct.

It also fixes a bunch of eslint errors and re-enables eslint in rollup.config.js.